### PR TITLE
Issue 19 core integrator class

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ O365==2.0.15
 pandas==1.3.2
 selenium==3.141.0
 xlwings==0.24.9
+openpyxl==3.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dynaconf==3.1.4
 O365==2.0.15
 pandas==1.3.2
 selenium==3.141.0
+xlwings==0.24.9

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,14 @@ setup(
     ),
     author="Department of General Services",
     author_email="william.daly@baltimorecity.gov",
-    install_requires=[],
+    install_requires=[
+        "dynaconf",
+        "O365",
+        "pandas",
+        "selenium",
+        "xlwings",
+        "openpyxl",
+    ],
     include_package_data=True,
     package_dir={"": "src"},  # this is required to access code in src/
     packages=find_packages(where="src"),  # same as above

--- a/src/aging_report/core_integrator/constants.py
+++ b/src/aging_report/core_integrator/constants.py
@@ -1,0 +1,12 @@
+# pylint: disable=line-too-long
+# flake8: noqa
+CORE_ELEMENTS = {
+    "report name": "Prompt Payment Report (Excluding Accounts Payable)",
+    "date box": "ctl00_ContentPlaceHolder1_HomepageTabContainer_HomePanel_ReportViewer_ParametersListView_ctrl0_ParameterValueTextBox",
+    "report label": "ctl00_ContentPlaceHolder1_HomepageTabContainer_HomePanel_ReportViewer_ReportViewerUpdatePanel",
+    "view report": "ctl00_ContentPlaceHolder1_HomepageTabContainer_HomePanel_ReportViewer_UpdateReportButton",
+    "export report": "ctl00_ContentPlaceHolder1_HomepageTabContainer_HomePanel_ReportViewer_ExcelExportImageButton",
+    "username box": "ctl00_ContentPlaceHolder1_UsernameTextBox",
+    "password box": "ctl00_ContentPlaceHolder1_PasswordTextBox",
+    "login button": "ctl00_ContentPlaceHolder1_LoginButton",
+}

--- a/src/aging_report/core_integrator/driver.py
+++ b/src/aging_report/core_integrator/driver.py
@@ -65,6 +65,8 @@ class Driver:
             "safebrowsing.enabled": True,
         }
         options.add_experimental_option("prefs", prefs)
+        # Addresses this issue: https://stackoverflow.com/a/63270005
+        options.add_experimental_option("excludeSwitches", ["enable-logging"])
 
         # creates driver
         if not driver_path.exists():

--- a/src/aging_report/core_integrator/driver.py
+++ b/src/aging_report/core_integrator/driver.py
@@ -8,7 +8,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as Expected
 from selenium.common.exceptions import (
     TimeoutException,
-    UnexpectedAlertPresentException,
     SessionNotCreatedException,
 )
 
@@ -18,16 +17,31 @@ from aging_report.config import settings
 class Driver:
     """A Selenium webdriver used to operate a Chrome browser"""
 
-    EXCEPTIONS = [
-        TimeoutException,
-        UnexpectedAlertPresentException,
-        SessionNotCreatedException,
-    ]
-
     def __init__(
-        self, archives_dir: Path = None, config: Dynaconf = settings
+        self,
+        download_dir: Path,
+        config: Dynaconf = settings,
     ) -> None:
         """Inits the Driver class with specific download directory
+
+        Parameters
+        ----------
+        download_dir: Path
+            Path to directory where downloads from the browser should be saved
+        driver_path: Path
+            Location where the latest version of chromedriver is downloaded
+        """
+        # get path to chromedriver and project root
+        self.driver_path = Path(config.chrome_driver_path)
+        self.download_dir = download_dir
+        self.driver = self.create_driver(self.download_dir, self.driver_path)
+
+    def create_driver(
+        self,
+        download_dir: Path,
+        driver_path: Path,
+    ) -> webdriver.Chrome:
+        """Configures a selenium webdriver with a specific download directory
 
         Parameters
         ----------
@@ -35,13 +49,33 @@ class Driver:
             Location where the latest version of chromedriver is downloaded
         download_dir: Path
             Path to directory where downloads from the browser should be saved
-        """
-        # get path to chromedriver and project root
-        driver_path = Path(config.chrome_driver_path)
-        archives = archives_dir or (Path.cwd() / "archives")
 
-        self.download_dir = archives / "core_integrator"
-        self.driver = self._create_driver(self.download_dir, driver_path)
+        Returns
+        -------
+        webdriver.Chrome
+            Selenium webdriver for Chrome with options configured
+        """
+        # sets default download directory
+        download_dir.mkdir(exist_ok=True, parents=True)
+        options = webdriver.ChromeOptions()
+        prefs = {
+            "download.default_directory": str(download_dir),
+            "download.prompt_for_download": False,
+            "download.directory_upgrade": True,
+            "safebrowsing.enabled": True,
+        }
+        options.add_experimental_option("prefs", prefs)
+
+        # creates driver
+        if not driver_path.exists():
+            message = f"No chromedriver found at '{driver_path}'"
+            raise FileNotFoundError(message)
+        try:
+            driver = webdriver.Chrome(str(driver_path), options=options)
+        except SessionNotCreatedException as error:
+            raise error
+
+        return driver
 
     def fill_in(self, element_id: str, content: str) -> None:
         """Uses the webdriver to fill in a form field with content
@@ -98,7 +132,7 @@ class Driver:
         elif loc_type == "link":
             by = By.PARTIAL_LINK_TEXT
         else:
-            raise KeyError
+            raise KeyError("Parameter loc_type must be one of ('id','link')")
 
         # try to locate the element within the given number of seconds
         try:
@@ -106,47 +140,6 @@ class Driver:
             WebDriverWait(self.driver, seconds).until(elem_present)
         except TimeoutException as error:
             raise error
-
-    def _create_driver(
-        self,
-        download_dir: Path,
-        driver_path: Path,
-    ) -> webdriver.Chrome:
-        """Configures a selenium webdriver with a specific download directory
-
-        Parameters
-        ----------
-        driver_path: Path
-            Location where the latest version of chromedriver is downloaded
-        download_dir: Path
-            Path to directory where downloads from the browser should be saved
-
-        Returns
-        -------
-        webdriver.Chrome
-            Selenium webdriver for Chrome with options configured
-        """
-        # sets default download directory
-        download_dir.mkdir(exist_ok=True, parents=True)
-        options = webdriver.ChromeOptions()
-        prefs = {
-            "download.default_directory": str(download_dir),
-            "download.prompt_for_download": False,
-            "download.directory_upgrade": True,
-            "safebrowsing.enabled": True,
-        }
-        options.add_experimental_option("prefs", prefs)
-
-        # creates driver
-        if not driver_path.exists():
-            message = f"No chromedriver found at '{driver_path}'"
-            raise FileNotFoundError(message)
-        try:
-            driver = webdriver.Chrome(str(driver_path), options=options)
-        except SessionNotCreatedException as error:
-            raise error
-
-        return driver
 
     def get(self, url) -> None:
         """Loads the webpage for a URL"""

--- a/src/aging_report/core_integrator/scraper.py
+++ b/src/aging_report/core_integrator/scraper.py
@@ -1,33 +1,160 @@
 from __future__ import annotations  # prevents NameError for typehints
+import time
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import xlwings as xl
+from dynaconf import Dynaconf
+from selenium.common.exceptions import (
+    TimeoutException,
+    UnexpectedAlertPresentException,
+    SessionNotCreatedException,
+)
+
+from aging_report.config import settings
+from aging_report.core_integrator.driver import Driver
+from aging_report.core_integrator.constants import CORE_ELEMENTS
 
 
 class CoreIntegrator:
     """Client for scraping data from the CoreIntegrator website"""
 
-    def __init__(self):
-        """Inits the CoreIntegrator class"""
-        pass
+    EXCEPTIONS = (
+        KeyError,
+        FileNotFoundError,
+        TimeoutException,
+        UnexpectedAlertPresentException,
+        SessionNotCreatedException,
+    )
 
-    def scrape_report(self) -> None:
+    def __init__(  # pylint: disable=dangerous-default-value
+        self,
+        elements: dict = CORE_ELEMENTS,
+        archives_dir: Path = None,
+        config: Dynaconf = settings,
+    ) -> None:
+        """Inits the CoreIntegrator class"""
+        # sets download directory and file names
+        report_name = elements["report name"]
+        archives_dir = archives_dir or (Path.cwd() / "archives")
+        download_dir = archives_dir / "core_integrator"
+        download_name = report_name + ".xlsx"
+        file_name = f"prompt_payment{str(date.today())}.xlsx"
+        # sets class attributes
+        self.elements = config
+        self.download_dir = download_dir
+        self.download_path = download_dir / download_name
+        self.file_path = download_dir / file_name
+        self.driver: Driver = None
+
+    def scrape_report(self, config: Dynaconf = settings) -> None:
         """Scrapes and downloads the Prompt Payment report from CoreIntegrator
         then loads it as a dataframe
         """
-        pass
+        # try to scrape the report, up to 10 attempts
+        for _ in range(10):
+            try:
+                self.driver = Driver(self.download_dir, config)
+                self._login()
+                self._access_report()
+                self._rename_download()
+                return self.load_report()
+            except self.EXCEPTIONS as e:
+                error = e
+            finally:
+                self.driver.quit()
+        raise error
 
-    def _login(self):
+    def _login(self, config: Dynaconf = settings) -> None:
         """Logs into the CoreIntegrator website"""
-        pass
+        # rename attributes and config vars for ease
+        driver = self.driver
+        elements = self.elements
+        username_field = elements["username box"]
+        password_field = elements["password box"]
+        login_button = elements["login button"]
+
+        # load CoreIntegrator site and enter credentials
+        driver.get(config["url"])
+        driver.wait_to_load(username_field, seconds=5)
+        driver.fill_in(username_field, config["core_username"])
+        driver.fill_in(password_field, config["core_password"])
+
+        # click the login button
+        try:
+            driver.click(login_button)
+        except UnexpectedAlertPresentException as error:
+            raise error
 
     def _access_report(self):
         """Searches for the Prompt Payment Report current through today's
         date and then exports the report to Excel
         """
-        pass
+        # rename attributes and config vars for ease
+        driver = self.driver
+        elements = self.elements
+        today = date.today().strftime("%m/%d/%Y")
+        report_link = elements["report name"]
+        date_field = elements["date box"]
+        report_label = elements["report_label"]
+        view_report = elements["view report"]
+        export_report = elements["export report"]
 
-    def _rename_download(self):
+        # click on the prompt payment link
+        driver.wait_to_load(report_link, loc_type="link")
+        driver.click(report_link, loc_type="link")
+
+        # enter today's date in the search box
+        driver.wait_to_load(date_field)
+        driver.fill_in(date_field, today)
+        driver.click(report_label)  # click out of date_field
+
+        # click view report button
+        driver.wait_to_load(view_report)
+        driver.click(view_report)
+
+        # export report
+        driver.wait_to_load(export_report, seconds=90)
+        driver.click(export_report)
+
+        # accept the dialog box to tigger the download
+        time.sleep(1)
+        driver.driver.switch_to.alert.accept()
+
+    def _rename_download(self, attempts=60):
         """Confirms report was downloaded and renames it"""
-        pass
+        # set local vars for ease
+        download_path = self.download_path
+        renamed_path = self.file_path
+        # try to locate the download for given number of attempts
+        counter = 0
+        while not download_path.exists():
+            counter += 1
+            time.sleep(1)
+            if counter > attempts:
+                message = (
+                    f"File not found at '{download_path}' "
+                    f"after {counter} seconds."
+                )
+                raise FileNotFoundError(message)
+        # rename downloaded file
+        download_path.replace(renamed_path)
 
-    def _load_report(self):
-        """Loads the report as a dataframe"""
-        pass
+    def load_report(self) -> pd.DataFrame:
+        """Automates the opening and saving of an excel workbook before reading it
+        in through pd.read_excel, which addresses the NaN issue described in this
+        post: https://stackoverflow.com/a/41730454/7338319
+        """
+        # check that the file exists
+        file = self.file_path
+        if not file.exists():
+            raise FileNotFoundError(f"Report wasn't found at location: {file}")
+        # open and save the wb to trigger formulas
+        app = xl.App(visible=False)
+        book = app.books.open(self.file_path)
+        book.save()
+        book.close()
+        app.kill()
+        # read the excel into a dataframe
+        return pd.read_excel(file, engine="openpyxl")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def fixture_archive_dir(tmp_path_factory):
     return archive_dir
 
 
-@pytest.fixture(scope="session", name="driver")
+@pytest.fixture(scope="module", name="driver")
 def fixture_driver(test_archive_dir):
     """Creates a webdriver for testing"""
     download_dir = test_archive_dir / "core_integrator"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def fixture_archive_dir(tmp_path_factory):
 @pytest.fixture(scope="session", name="driver")
 def fixture_driver(test_archive_dir):
     """Creates a webdriver for testing"""
-    driver = Driver(test_archive_dir)
+    download_dir = test_archive_dir / "core_integrator"
+    driver = Driver(download_dir)
     yield driver
     driver.quit()

--- a/tests/integration_tests/core_integrator/test_driver.py
+++ b/tests/integration_tests/core_integrator/test_driver.py
@@ -37,14 +37,14 @@ class TestDriver:
         assert isinstance(driver, Driver)
         assert any(download_dir.iterdir()) is True
 
-    def test_missing_driver(self, test_archive_dir):
+    def test_missing_driver(self, test_archive_dir, monkeypatch):
         """Tests that create_driver() returns an error if the chromedriver
         file doesn't exist at the path specified in config.json
         """
         # setup
         driver_path = Path.cwd() / "fake"
         assert driver_path.exists() is False
-        settings.chrome_driver_path = driver_path
+        monkeypatch.setattr(settings, "chrome_driver_path", driver_path)
         # executive
         with pytest.raises(FileNotFoundError):
             Driver(test_archive_dir, config=settings)

--- a/tests/integration_tests/core_integrator/test_driver.py
+++ b/tests/integration_tests/core_integrator/test_driver.py
@@ -37,7 +37,7 @@ class TestDriver:
         assert isinstance(driver, Driver)
         assert any(download_dir.iterdir()) is True
 
-    def test_missing_driver(self):
+    def test_missing_driver(self, test_archive_dir):
         """Tests that create_driver() returns an error if the chromedriver
         file doesn't exist at the path specified in config.json
         """
@@ -47,7 +47,7 @@ class TestDriver:
         settings.chrome_driver_path = driver_path
         # executive
         with pytest.raises(FileNotFoundError):
-            Driver(config=settings)
+            Driver(test_archive_dir, config=settings)
 
 
 class TestClick:

--- a/tests/integration_tests/core_integrator/test_scraper.py
+++ b/tests/integration_tests/core_integrator/test_scraper.py
@@ -1,0 +1,27 @@
+import faulthandler
+
+import pandas as pd
+
+from aging_report.core_integrator.scraper import CoreIntegrator
+
+
+def test_scraper(test_archive_dir):
+    """Tests that CoreIntegrator.scrape_report() executes correctly
+
+    Validates the following conditions:
+    - The method doesn't raise any errors
+    - The report was downloaded to the archives directory
+    - It returns a dataframe
+    - The values in the Execution ID column are populated
+    """
+    # setup
+    faulthandler.disable()
+    scraper = CoreIntegrator(test_archive_dir)
+    # execution
+    df = scraper.scrape_report(attempts=2)
+    print(df.head())
+    faulthandler.enable()
+    # validation
+    assert scraper.file_path.exists()
+    assert isinstance(df, pd.DataFrame)
+    assert all(pd.notna(df["Execution ID"]))

--- a/tests/unit_tests/core_integrator/test_scraper.py
+++ b/tests/unit_tests/core_integrator/test_scraper.py
@@ -1,0 +1,12 @@
+from aging_report.core_integrator.scraper import CoreIntegrator
+
+
+class TestCoreIntegrator:
+    """Manages unit tests for CoreIntegrator class"""
+
+    def test_init(self):
+        """Tests that CoreIntegrator instantiates correctly"""
+        # execution
+        CoreIntegrator()
+        # validation
+        assert 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, lint, checkdeps, pytest, coverage
+envlist = py37, py38, py39, lint, checkdeps, pytest
 skipsdist = false
 skip_missing_interpreters = true
 


### PR DESCRIPTION
## Summary

Implements the `CoreIntegrator` class in `aging_report/core_integrator/scraper.py` along with the associated integration tests

Fixes #19 

## Changes Proposed

- Implement the following methods within the `CoreIntegrator` class
  - `_login()` Logs into CoreIntegrator
  - `_access_report()` Searches for the Prompt Payment report in CoreIntegrator
  - `_rename_download()` Renames the downloaded report
  - `_load_report()` Opens the report via `xlwings` to save the calculations then loads the report as a dataframe
  - `scrape_report()` Public method that executes the full scrape and download workflow and returns the report as a dataframe
- Creates a test for `scrape_report()` in `tests/integration_tests/core_integrator/test_scraper.py`
- Switches the GitHub actions to run on `windows-latest` in order to allow for `xlwings` to be installed
- Removes `py36` and `coverage` from `tox.ini` test env list

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run `pip install -r requirements.txt` to install new dependencies
1. Run `pytest tests/integration_tests/` to run the integration tests, all tests should pass
