### PR TITLE
Issue 29 citibuy scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ If you receive an error message, or the version of python you have installed is 
 To retrieve a list of all of the invoices in the Priority Vendor Aging SharePoint list complete the following steps:
 
 1. Initiate a new Python interpreter in your terminal: `python`
-1. Import the `Client` class: `from aging_report.sharepoint import Client`
-1. Instantiate the `Client` class: `client = Client()`
+1. Import the `Client` class: `from aging_report.sharepoint import SharePoint`
+1. Instantiate the `Client` class: `client = SharePoint()`
 1. Get an instance of the `AgingReportList` class: `report = client.get_aging_report()`
 1. Query the list of invoices: `invoices = report.get_invoices()`
 1. Print the invoice fields:
@@ -141,9 +141,9 @@ for invoice in invoices:
 The full example looks like this:
 
 ```python
-from aging_report.sharepoint import Client
+from aging_report.sharepoint import SharePoint
 
-client = Client()
+client = SharePoint()
 report = client.get_aging_report()
 invoices = report.get_invoices()
 for i in invoices:

--- a/src/aging_report/citibuy/__init__.py
+++ b/src/aging_report/citibuy/__init__.py
@@ -1,0 +1,5 @@
+__all__ = ["PurchaseOrder", "Invoice"]
+
+from aging_report.citibuy.client import CitiBuy
+from aging_report.citibuy.invoice import Invoice
+from aging_report.citibuy.purchase_order import PurchaseOrder

--- a/src/aging_report/citibuy/__init__.py
+++ b/src/aging_report/citibuy/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["PurchaseOrder", "Invoice"]
+__all__ = ["CitiBuy", "Invoice", "PurchaseOrder"]
 
 from aging_report.citibuy.client import CitiBuy
 from aging_report.citibuy.invoice import Invoice

--- a/src/aging_report/citibuy/client.py
+++ b/src/aging_report/citibuy/client.py
@@ -1,0 +1,16 @@
+from __future__ import annotations  # prevents NameError for typehints
+from typing import List
+
+from dynaconf import Dynaconf
+
+
+class CitiBuy:
+    """Client that interfaces with the CitiBuy backend"""
+
+    def __init__(self, config: Dynaconf) -> None:
+        """Instantiates the CitiBuy class"""
+        pass
+
+    def query_many(self, query_str) -> List[dict]:
+        """Executes a query and returns the results as a list of dicts"""
+        pass

--- a/src/aging_report/citibuy/client.py
+++ b/src/aging_report/citibuy/client.py
@@ -3,11 +3,13 @@ from typing import List
 
 from dynaconf import Dynaconf
 
+from aging_report.config import settings
+
 
 class CitiBuy:
     """Client that interfaces with the CitiBuy backend"""
 
-    def __init__(self, config: Dynaconf) -> None:
+    def __init__(self, config: Dynaconf = settings) -> None:
         """Instantiates the CitiBuy class"""
         pass
 

--- a/src/aging_report/citibuy/invoice.py
+++ b/src/aging_report/citibuy/invoice.py
@@ -9,7 +9,7 @@ class Invoice(CitiBuy):
 
     def __init__(self) -> None:
         """Instantiates the Invoice class"""
-        pass
+        super().__init__()
 
     def get_invoices(
         self,

--- a/src/aging_report/citibuy/invoice.py
+++ b/src/aging_report/citibuy/invoice.py
@@ -1,0 +1,39 @@
+from __future__ import annotations  # prevents NameError for typehints
+from typing import List, Dict
+
+from aging_report.citibuy.client import CitiBuy
+
+
+class Invoice(CitiBuy):
+    """Client that organizes queries of Invoice data from CitiBuy"""
+
+    def __init__(self) -> None:
+        """Instantiates the Invoice class"""
+        pass
+
+    def get_invoices(
+        self,
+        limit: int = 100,
+        filter_dict: Dict[str, tuple] = None,
+    ) -> List[dict]:
+        """Gets a list of Invoices from CitiBuy and returns them as a list
+        of dictionaries
+
+        Parameters
+        ----------
+        limit: int
+            Number of records to return from the query results
+        filter_dict: Dict[str, tuple]
+            Conditions applied to fields on the PO used to filter the results.
+            Must be passed in this format: {"col_name": ("equals", "dog")}
+
+        Returns
+        -------
+        List[dict]
+            A list of results as a dictionary keyed by the column names
+        """
+        pass
+
+    def update_invoice_list(self) -> None:
+        """Updates the Invoice SharePoint list with data from CitiBuy"""
+        pass

--- a/src/aging_report/citibuy/purchase_order.py
+++ b/src/aging_report/citibuy/purchase_order.py
@@ -2,7 +2,7 @@ from __future__ import annotations  # prevents NameError for typehints
 from typing import List, Dict
 
 from aging_report.citibuy.client import CitiBuy
-from aging_report.sharepoint import Client, ArchiveFolder
+from aging_report.sharepoint import SharePoint
 
 
 class PurchaseOrder(CitiBuy):
@@ -10,7 +10,8 @@ class PurchaseOrder(CitiBuy):
 
     def __init__(self) -> None:
         """Instantiates the Purchase Order class"""
-        pass
+        super().__init__()
+        self.sharepoint = SharePoint()
 
     def get_purchas_orders(
         self,

--- a/src/aging_report/citibuy/purchase_order.py
+++ b/src/aging_report/citibuy/purchase_order.py
@@ -1,0 +1,43 @@
+from __future__ import annotations  # prevents NameError for typehints
+from typing import List, Dict
+
+from aging_report.citibuy.client import CitiBuy
+from aging_report.sharepoint import Client, ArchiveFolder
+
+
+class PurchaseOrder(CitiBuy):
+    """Client that organizes queries of Purchase Order data from CitiBuy"""
+
+    def __init__(self) -> None:
+        """Instantiates the Purchase Order class"""
+        pass
+
+    def get_purchas_orders(
+        self,
+        limit: int = 100,
+        filter_dict: Dict[str, tuple] = None,
+    ) -> List[dict]:
+        """Gets a list of POs from CitiBuy and returns them as a list of dicts
+
+        Parameters
+        ----------
+        limit: int
+            Number of records to return from the query results
+        filter_dict: Dict[str, tuple]
+            Conditions applied to fields on the PO used to filter the results.
+            Must be passed in this format: {"col_name": ("equals", "dog")}
+
+        Returns
+        -------
+        List[dict]
+            A list of results as a dictionary keyed by the column names
+        """
+        pass
+
+    def update_po_list(self) -> None:
+        """Updates the Purchase Order SharePoint list with data from CitiBuy"""
+        pass
+
+    def update_vendor_list(self) -> None:
+        """Updates the Vendor SharePoint list with data from CitiBuy"""
+        pass

--- a/src/aging_report/sharepoint/__init__.py
+++ b/src/aging_report/sharepoint/__init__.py
@@ -5,4 +5,4 @@ from aging_report.sharepoint.aging_report import (
     AgingReportItem,
 )
 from aging_report.sharepoint.archive import ArchiveFolder
-from aging_report.sharepoint.client import Client
+from aging_report.sharepoint.client import SharePoint

--- a/src/aging_report/sharepoint/client.py
+++ b/src/aging_report/sharepoint/client.py
@@ -12,7 +12,7 @@ from aging_report.sharepoint.archive import ArchiveFolder
 from aging_report.sharepoint.utils import authenticate_account
 
 
-class Client:
+class SharePoint:
     """Creates a SharePoint client for the DGS Fiscal site
 
     Facilitates accessing lists and drives in the DGS SharePoint site using

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from aging_report.config import settings
-from aging_report.sharepoint import Client
+from aging_report.sharepoint import SharePoint
 from aging_report.core_integrator.driver import Driver
 
 collect_ignore = ["integration_tests"]
@@ -20,7 +20,7 @@ def test_config():
 @pytest.fixture(scope="session", name="test_client")
 def fixture_test_client():
     """Creates an authenticated Graph API client for use in integration tests"""
-    return Client()
+    return SharePoint()
 
 
 @pytest.fixture(scope="session", name="test_report")

--- a/tests/integration_tests/citibuy/test_client.py
+++ b/tests/integration_tests/citibuy/test_client.py
@@ -1,0 +1,9 @@
+from aging_report.citibuy import CitiBuy
+
+
+class TestCitiBuy:
+    """Tests the CitiBuy class"""
+
+    def test_init_success(self):
+        """Tests that the CitiBuy class instantiates correctly"""
+        assert 1

--- a/tests/integration_tests/citibuy/test_client.py
+++ b/tests/integration_tests/citibuy/test_client.py
@@ -6,4 +6,7 @@ class TestCitiBuy:
 
     def test_init_success(self):
         """Tests that the CitiBuy class instantiates correctly"""
+        # setup
+        CitiBuy()
+        # validation
         assert 1


### PR DESCRIPTION
## Summary

Creates the scaffolding for `aging_report/citibuy/` sub-package

Fixes #29 

## Changes Proposed

- Create the following modules in `aging_report/citibuy/`
  - An `aging_report/citibuy/client.py` with a `CitiBuy` class that establishes a connection to the CitiBuy database and sets up basic queries
  - An `aging_report/citibuy/purchase_order.py` module with `PurchaseOrders` class that is used to query the list of POs from CitiBuy and upload them to SharePoint
  - An `aging_report/citibuy/invoice.py` module with `Invoices` class that is used to query the list of Invoices from CitiBuy and upload them to SharePoint
- Set up tests in `tests/integration_tests/citibuy`
- Renamed `Client` class to `SharePoint` in `aging_report.sharepoint`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run all of the code quality checks: `tox` 
1. All checks should pass
