### PR TITLE
Issue 61 contract management setup

### DIFF
--- a/app/src/dgs_fiscal/etl/__init__.py
+++ b/app/src/dgs_fiscal/etl/__init__.py
@@ -1,3 +1,4 @@
 __all__ = ["PromptPayment"]
 
 from dgs_fiscal.etl.prompt_payment import PromptPayment
+from dgs_fiscal.etl.contract_management import ContractManagement

--- a/app/src/dgs_fiscal/etl/contract_management/__init__.py
+++ b/app/src/dgs_fiscal/etl/contract_management/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["ContractManagement"]
+
+from dgs_fiscal.etl.contract_management.main import ContractManagement

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -1,0 +1,66 @@
+from __future__ import annotations  # prevents NameError for typehints
+from typing import List
+
+from dgs_fiscal.systems import CitiBuy, SharePoint
+from dgs_fiscal.systems.sharepoint import BatchedChanges
+
+
+class ContractManagement:
+    """Runs the Contract Management workflow, which gets the list of active
+    Purchase Orders and vendors from CitiBuy and adds them to SharePoint
+
+    Attributes
+    ----------
+    citibuy: CitiBuy
+        An instance of the CitiBuy class which connects to and queries data
+        from the CitiBuy database
+    sharepoint: SharePoint
+        Instance of SharePoint class used to read and write to the SharePoint
+        lists and folders associated with the Contract Management workflow
+    """
+
+    def __init__(self) -> None:
+        """Inits the ContractManagement class"""
+        self.citibuy = CitiBuy()
+        self.sharepoint = SharePoint()
+
+    def get_citibuy_data(self, dataset: str) -> List[dict]:
+        """Gets the list of active or recently closed Purchase Orders and the
+        unique list of DGS vendors from CitiBuy
+        """
+        pass
+
+    def get_sharepoint_data(self, dataset: str) -> List[dict]:
+        """Get current POs and Vendors from their respective SharePoint lists"""
+        pass
+
+    def reconcile_lists(
+        self,
+        citibuy_data: List[dict],
+        sharepoint_data: List[dict],
+    ) -> BatchedChanges:
+        """Compares the lists of POs and vendors pulled from CitiBuy with the
+        data currently in SharePoint and returns a list of the changes to make
+
+        Parameters
+        ----------
+        citibuy_data: List[dict]
+            A DataFrame of the new Prompt Payment report that was scraped from
+            CoreIntegrator
+        sharepoint_data: List[dict]
+            A DataFrame of the records added or updated in SharePoint in the
+            previous run of the Prompt Payment report
+        """
+        pass
+
+    def update_sharepoint(self, changes: BatchedChanges) -> None:
+        """Updates sharepoint with the set of changes returned by the
+        self.reconcile_reports() method
+
+        Parameters
+        ----------
+        changes: BatchedChanges
+            An instance of BatchedChanges that contains the list changes that
+            need to be made to the Invoices list in SharePoint
+        """
+        pass

--- a/app/src/dgs_fiscal/etl/prompt_payment/main.py
+++ b/app/src/dgs_fiscal/etl/prompt_payment/main.py
@@ -10,8 +10,8 @@ from dgs_fiscal.etl.prompt_payment import constants
 
 
 class PromptPayment:
-    """Manages access to the Prompt Payment Report in CoreIntegrator, which
-    serves as a data source for updates to the Aging Report in SharePoint
+    """Runs the Prompt Payment workflow, which scrapes the new Prompt Payment
+    report from CoreIntegrator then updates the previous report in SharePoint
 
     Attributes
     ----------
@@ -47,7 +47,7 @@ class PromptPayment:
         Returns
         -------
         pd.DataFrame
-            DataFrame of the Prompt Payment Report from CoreIntegrator
+            DataFrame of the new Prompt Payment Report from CoreIntegrator
         """
         dtypes = constants.NEW_REPORT["dtypes"]
         columns = constants.NEW_REPORT["columns"]
@@ -88,7 +88,7 @@ class PromptPayment:
         Returns
         -------
         pd.DataFrame
-            A dataframe of the Prompt Payment report pulled from SharePoint
+            A dataframe of the old Prompt Payment report pulled from SharePoint
         """
         invoice_list = self.sharepoint.get_list("Invoices")
 
@@ -102,7 +102,7 @@ class PromptPayment:
         old_report,
     ) -> BatchedChanges:
         """Merges the old report from SharePoint with the new report scraped
-        from CoreIntegrator and return a list of the changes
+        from CoreIntegrator and return a list of the changes to make
 
         Parameters
         ----------

--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -3,10 +3,10 @@ from typing import List, Dict
 
 import pyodbc
 import sqlalchemy
-from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy.engine import URL, Row
 from dynaconf import Dynaconf
+import pandas as pd
 
 from dgs_fiscal.config import settings
 from dgs_fiscal.systems.citibuy import models
@@ -40,7 +40,7 @@ class CitiBuy:
             conn_url = URL.create(
                 "mssql+pyodbc", query={"odbc_connect": conn_str}
             )
-        self.engine = create_engine(conn_url)
+        self.engine = sqlalchemy.create_engine(conn_url)
         self._purchase_orders: Records = None
 
     @property
@@ -105,7 +105,7 @@ class CitiBuy:
         con_cols = [getattr(con, col) for col in con.columns]
 
         # build the base query
-        query = select(*po_cols, *ven_cols, *con_cols).limit(limit)
+        query = sqlalchemy.select(*po_cols, *ven_cols, *con_cols).limit(limit)
         query = query.join(po, po.vendor_id == ven.id)
         query = query.join(
             con,
@@ -172,4 +172,4 @@ class DatabaseRows:
     @property
     def records(self) -> List[dict]:
         """Returns the rows as a list of dictionaries"""
-        return [row._mapping for row in self.rows]
+        return [row._asdict() for row in self.rows]

--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -106,13 +106,15 @@ class CitiBuy:
 
         # build the base query
         query = sqlalchemy.select(*po_cols, *ven_cols, *con_cols).limit(limit)
-        query = query.join(po, po.vendor_id == ven.id)
-        query = query.join(
-            con,
-            (po.po_nbr == con.po_nbr) & (po.release_nbr == con.release_nbr),
-            isouter=True,
+        query = query.join(po, po.vendor_id == ven.vendor_id)
+        query = query.join(con, po.po_nbr == con.po_nbr, isouter=True)
+        query = query.where(
+            (con.contract_agency.in_(("DGS", "AGY")))
+            | (con.contract_agency.is_(None))
         )
-        query = query.where(po.agency.in_(("DGS", "AGY")))
+        query = query.where((po.agency == "DGS") | (po.release_nbr == 0))
+        query = query.where(po.status.notin_(("3PCO", "3PCA")))
+        print(query)
 
         with Session(self.engine) as session:
             cursor = session.execute(query)

--- a/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
@@ -7,7 +7,7 @@ class Vendor(db.Base):
     __tablename__ = "VENDOR"
 
     # columns
-    id = db.Column("VENDOR_NBR", db.String, primary_key=True)
+    vendor_id = db.Column("VENDOR_NBR", db.String, primary_key=True)
     name = db.Column("NAME", db.String)
     contact = db.Column("EMA_CONTACT_NAME", db.String)
     email = db.Column("EMA_EMAIL", db.String)

--- a/app/tests/integration_tests/citibuy/test_client.py
+++ b/app/tests/integration_tests/citibuy/test_client.py
@@ -15,11 +15,12 @@ class TestCitiBuy:
 
     def test_init(self, test_citibuy):
         """Tests that the mock CitiBuy db was populated correctly"""
+        # setup
+        query = "SELECT TOP 5 PO_NBR, RELEASE_NBR FROM PO_HEADER"
+        # execution
+        results = test_citibuy.execute_stmt(query)
+        print(results.records)
         # validation
         assert isinstance(test_citibuy.engine, sqlalchemy.engine.Engine)
-        with pytest.raises(NotImplementedError):
-            print(test_citibuy.purchase_orders)
-        with pytest.raises(NotImplementedError):
-            print(test_citibuy.vendors)
-        with pytest.raises(NotImplementedError):
-            print(test_citibuy.invoices)
+        assert isinstance(results.records, list)
+        assert len(results.records) == 5

--- a/app/tests/unit_tests/citibuy/test_client.py
+++ b/app/tests/unit_tests/citibuy/test_client.py
@@ -1,8 +1,6 @@
 from pprint import pprint
 
 import pytest
-import pandas as pd
-import numpy as np
 import sqlalchemy
 
 from tests.utils import citibuy_data as data

--- a/app/tests/unit_tests/citibuy/test_client.py
+++ b/app/tests/unit_tests/citibuy/test_client.py
@@ -43,10 +43,6 @@ class TestCitiBuy:
         assert isinstance(mock_citibuy.engine, sqlalchemy.engine.Engine)
         with pytest.raises(NotImplementedError):
             print(mock_citibuy.purchase_orders)
-        with pytest.raises(NotImplementedError):
-            print(mock_citibuy.vendors)
-        with pytest.raises(NotImplementedError):
-            print(mock_citibuy.invoices)
 
 
 class TestGetPurchaseOrders:

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -1,22 +1,22 @@
-VENDORS = [
-    {
-        "id": "111",
+VENDORS = {
+    "acme": {
+        "vendor_id": "111",
         "name": "Acme",
         "contact": "Jane Doe",
         "email": "jane.doe@acme.com",
         "phone": "(111) 111-1111",
     },
-    {
-        "id": "222",
+    "disney": {
+        "vendor_id": "222",
         "name": "Disney",
         "contact": "Anthony Williams",
         "email": "anthony.williams@disney.com",
         "phone": "(222) 222-2222",
     },
-]
+}
 
-PURCHASE_ORDERS = [
-    {
+PO_RECORDS = {
+    "po1": {
         "po_nbr": "111",
         "release_nbr": 0,
         "vendor_id": "111",
@@ -25,7 +25,7 @@ PURCHASE_ORDERS = [
         "cost": None,
         "date": None,
     },
-    {
+    "po1_1": {
         "po_nbr": "111",
         "release_nbr": 1,
         "vendor_id": "111",
@@ -34,7 +34,16 @@ PURCHASE_ORDERS = [
         "cost": 75.00,
         "date": None,
     },
-    {
+    "po1_2": {
+        "po_nbr": "111",
+        "release_nbr": 2,
+        "vendor_id": "222",
+        "status": "3PPR",
+        "agency": "DPW",
+        "cost": 20.00,
+        "date": None,
+    },
+    "po2": {
         "po_nbr": "222",
         "release_nbr": 0,
         "vendor_id": "222",
@@ -43,16 +52,7 @@ PURCHASE_ORDERS = [
         "cost": 15.50,
         "date": None,
     },
-    {
-        "po_nbr": "333",
-        "release_nbr": 0,
-        "vendor_id": "222",
-        "status": "3PPR",
-        "agency": "AGY",
-        "cost": 20.00,
-        "date": None,
-    },
-    {
+    "po4": {
         "po_nbr": "444",
         "release_nbr": 0,
         "vendor_id": "222",
@@ -61,19 +61,37 @@ PURCHASE_ORDERS = [
         "cost": 0.00,
         "date": None,
     },
-    {
+    "po4_1": {
         "po_nbr": "444",
         "release_nbr": 1,
         "vendor_id": "222",
-        "status": "3PCO",
-        "agency": "DPW",
+        "status": "3PPR",
+        "agency": "DGS",
         "cost": 10.00,
         "date": None,
     },
-]
+    "po5": {
+        "po_nbr": "555",
+        "release_nbr": 0,
+        "vendor_id": "111",
+        "status": "3PS",
+        "agency": "DGS",
+        "cost": 20.00,
+        "date": None,
+    },
+    "po6": {
+        "po_nbr": "666",
+        "release_nbr": 0,
+        "vendor_id": "111",
+        "status": "3PS",
+        "agency": "DPW",
+        "cost": 20.00,
+        "date": None,
+    },
+}
 
-INVOICES = [
-    {
+INVOICES = {
+    "inv1": {
         "id": "invoice1",
         "po_nbr": "111",
         "release_nbr": 1,
@@ -83,7 +101,7 @@ INVOICES = [
         "amount": 10.25,
         "invoice_date": None,
     },
-    {
+    "inv2": {
         "id": "invoice2",
         "po_nbr": "111",
         "release_nbr": 1,
@@ -93,7 +111,7 @@ INVOICES = [
         "amount": 25.00,
         "invoice_date": None,
     },
-    {
+    "inv3": {
         "id": "invoice3",
         "po_nbr": "111",
         "release_nbr": 1,
@@ -103,7 +121,7 @@ INVOICES = [
         "amount": 25.00,
         "invoice_date": None,
     },
-    {
+    "inv4": {
         "id": "invoice4",
         "po_nbr": "111",
         "release_nbr": 1,
@@ -113,7 +131,7 @@ INVOICES = [
         "amount": 10.50,
         "invoice_date": None,
     },
-    {
+    "disney_inv5": {
         "id": "invoice5",
         "po_nbr": "222",
         "release_nbr": 0,
@@ -123,7 +141,7 @@ INVOICES = [
         "amount": 10.50,
         "invoice_date": None,
     },
-    {
+    "disney_inv6": {
         "id": "invoice6",
         "po_nbr": "222",
         "release_nbr": 0,
@@ -133,7 +151,7 @@ INVOICES = [
         "amount": 5.00,
         "invoice_date": None,
     },
-    {
+    "disney_inv7": {
         "id": "invoice7",
         "po_nbr": "333",
         "release_nbr": 0,
@@ -143,7 +161,7 @@ INVOICES = [
         "amount": 5.00,
         "invoice_date": None,
     },
-    {
+    "disney_inv8": {
         "id": "invoice8",
         "po_nbr": "444",
         "release_nbr": 1,
@@ -153,10 +171,10 @@ INVOICES = [
         "amount": 10.00,
         "invoice_date": None,
     },
-]
+}
 
-BLANKET_CONTRACTS = [
-    {
+CONTRACTS = {
+    "blanket1": {
         "po_nbr": "111",
         "release_nbr": 0,
         "contract_agency": "DGS",
@@ -165,13 +183,29 @@ BLANKET_CONTRACTS = [
         "dollar_limit": 1000.00,
         "dollar_spent": 50.00,
     },
-    {
+    "blanket4": {
         "po_nbr": "444",
         "release_nbr": 0,
-        "contract_agency": "DPW",
+        "contract_agency": "AGY",
         "start_date": None,
         "end_date": None,
         "dollar_limit": 500.00,
         "dollar_spent": 10.00,
+    },
+}
+
+PO_RESULTS = [
+    {**CONTRACTS["blanket1"], **PO_RECORDS["po1"], **VENDORS["acme"]},
+    {**CONTRACTS["blanket1"], **PO_RECORDS["po1_1"], **VENDORS["acme"]},
+    {**CONTRACTS["blanket4"], **PO_RECORDS["po4"], **VENDORS["disney"]},
+    {**CONTRACTS["blanket4"], **PO_RECORDS["po4_1"], **VENDORS["disney"]},
+    {
+        **PO_RECORDS["po5"],
+        **VENDORS["disney"],
+        "contract_agency": None,
+        "start_date": None,
+        "end_date": None,
+        "dollar_limit": None,
+        "dollar_spent": None,
     },
 ]

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 VENDORS = {
     "acme": {
         "vendor_id": "111",
@@ -22,7 +24,7 @@ PO_RECORDS = {
         "vendor_id": "111",
         "status": "3PS",
         "agency": "DGS",
-        "cost": None,
+        "cost": 0.00,
         "date": None,
     },
     "po1_1": {
@@ -86,6 +88,15 @@ PO_RECORDS = {
         "status": "3PS",
         "agency": "DPW",
         "cost": 20.00,
+        "date": None,
+    },
+    "po7": {
+        "po_nbr": "777",
+        "release_nbr": 0,
+        "vendor_id": "222",
+        "status": "3PCO",
+        "agency": "DGS",
+        "cost": 0.00,
         "date": None,
     },
 }
@@ -178,8 +189,8 @@ CONTRACTS = {
         "po_nbr": "111",
         "release_nbr": 0,
         "contract_agency": "DGS",
-        "start_date": None,
-        "end_date": None,
+        "start_date": datetime(2020, 7, 1),
+        "end_date": datetime(2050, 7, 1),
         "dollar_limit": 1000.00,
         "dollar_spent": 50.00,
     },
@@ -187,10 +198,19 @@ CONTRACTS = {
         "po_nbr": "444",
         "release_nbr": 0,
         "contract_agency": "AGY",
-        "start_date": None,
-        "end_date": None,
+        "start_date": datetime(2021, 7, 1),
+        "end_date": datetime(2050, 7, 1),
         "dollar_limit": 500.00,
         "dollar_spent": 10.00,
+    },
+    "blanket7": {
+        "po_nbr": "777",
+        "release_nbr": 0,
+        "contract_agency": "DGS",
+        "start_date": datetime(2010, 7, 1),
+        "end_date": datetime(2020, 7, 1),
+        "dollar_limit": 500.00,
+        "dollar_spent": 20.00,
     },
 }
 
@@ -201,7 +221,7 @@ PO_RESULTS = [
     {**CONTRACTS["blanket4"], **PO_RECORDS["po4_1"], **VENDORS["disney"]},
     {
         **PO_RECORDS["po5"],
-        **VENDORS["disney"],
+        **VENDORS["acme"],
         "contract_agency": None,
         "start_date": None,
         "end_date": None,

--- a/app/tests/utils/populate_citibuy_db.py
+++ b/app/tests/utils/populate_citibuy_db.py
@@ -29,10 +29,10 @@ def populate_db(session: Session) -> None:
     session: Session
         A SQLAlchemy session object passed to this function by the fixture
     """
-    vendors = [models.Vendor(**vendor) for vendor in data.VENDORS]
-    pos = [models.PurchaseOrder(**po) for po in data.PURCHASE_ORDERS]
-    invoices = [models.Invoice(**invoice) for invoice in data.INVOICES]
-    contracts = [models.BlanketContract(**c) for c in data.BLANKET_CONTRACTS]
+    vendors = [models.Vendor(**vendor) for vendor in data.VENDORS.values()]
+    pos = [models.PurchaseOrder(**po) for po in data.PO_RECORDS.values()]
+    invoices = [models.Invoice(**inv) for inv in data.INVOICES.values()]
+    contracts = [models.BlanketContract(**c) for c in data.CONTRACTS.values()]
     add_to_session(session, vendors)
     add_to_session(session, pos)
     add_to_session(session, invoices)


### PR DESCRIPTION
## Summary

Sets up the `etl/contract_management/` sub-package

Fixes #61 

## Changes Proposed

- Adds `etl/contract_management/main.py` with `ContractManagement` class
- Fixes query in `CitiBuy.get_purchase_orders()`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run unit tests: `pytest`
1. All tests should pass
