### PR TITLE
Issue 65 reconcile lists

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -62,3 +62,6 @@ disable = [
   "W0511",  # Disables fix me
   "R0801",  # Disables similar lines
 ]
+
+[tool.pylint."DESIGN"]
+max-locals=20

--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -3,6 +3,7 @@ CITIBUY = {
         "po_title": "Title",
         "po_nbr": "PO Number",
         "release_nbr": "Release Number",
+        "po_type": "PO Type",
         "vendor_id": "Vendor ID",
         "name": "Vendor",
         "status": "Status",

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -52,6 +52,13 @@ class ContractManagement:
             "P" + df["po_nbr"] + ":" + release,  # otherwise: 'P12345:1'
         )
 
+        # sets the PO type
+        blanket_po = (release == "0") & (df["start_date"].notna())
+        open_market = (release == "0") & (df["start_date"].isna())
+        df["po_type"] = "Release"
+        df.loc[blanket_po, "po_type"] = "Master Blanket"
+        df.loc[open_market, "po_type"] = "Open Market"
+
         # isloate and format PO dataframe
         df_po = df[po_cols.keys()]
         df_po.columns = po_cols.values()
@@ -71,7 +78,6 @@ class ContractManagement:
         ContractData
             A ContractData instance of the PO and vendor data from CitiBuy
         """
-
         # get the SharePoint list clients
         ven_list = self.sharepoint.get_list("Vendors")
         po_list = self.sharepoint.get_list("Purchase Orders")

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # prevents NameError for typehints
 from typing import List
 from dataclasses import dataclass
+from pprint import pprint
 
 import pandas as pd
 import numpy as np
@@ -92,36 +93,87 @@ class ContractManagement:
 
         return ContractData(po=df_po, vendor=df_ven)
 
-    def reconcile_lists(
+    def update_sharepoint(
         self,
-        citibuy_data: List[dict],
-        sharepoint_data: List[dict],
+        citibuy_data: pd.DataFrame,
+        sharepoint_data: pd.DataFrame,
     ) -> BatchedChanges:
-        """Compares the lists of POs and vendors pulled from CitiBuy with the
-        data currently in SharePoint and returns a list of the changes to make
+        """Compares the lists of vendors pulled from CitiBuy to the vendors
+        in SharePoint and returns a list of the changes to make in SharePoint
 
         Parameters
         ----------
-        citibuy_data: List[dict]
-            A DataFrame of the new Prompt Payment report that was scraped from
-            CoreIntegrator
-        sharepoint_data: List[dict]
-            A DataFrame of the records added or updated in SharePoint in the
-            previous run of the Prompt Payment report
+        citibuy_data: ContractData
+            An instance of ContractData for the new PO and Vendor records
+            retrieved from CitiBuy
+        sharepoint_data: ContractData
+            An instance of ContractData for the existing PO and Vendor records
+            in SharePoint
         """
-        pass
+        # extract the old and new datasets
+        new_po = citibuy_data.po.replace({np.nan: None})
+        old_po = sharepoint_data.po.replace({np.nan: None})
+        new_ven = citibuy_data.vendor
+        old_ven = sharepoint_data.vendor
 
-    def update_sharepoint(self, changes: BatchedChanges) -> None:
-        """Updates sharepoint with the set of changes returned by the
-        self.reconcile_reports() method
+        # update the list of vendors
+        ven_changes = self.detect_changes(
+            old_ven.to_dict("records"),
+            new_ven.to_dict("records"),
+            key_col="Vendor ID",
+        )
+        print("VEN UPDATES")
+        pprint(ven_changes.updates)
+        print("VEN INSERTS")
+        pprint(ven_changes.inserts)
+        # ven_updates = ven_list.batch_upsert(changes)
 
-        Parameters
-        ----------
-        changes: BatchedChanges
-            An instance of BatchedChanges that contains the list changes that
-            need to be made to the Invoices list in SharePoint
-        """
-        pass
+        # # extract new lookup ids from batch upsert
+        # new_lookup_ids = {}
+        # for update in ven_updates:
+        #     if update["status"] == 201:
+        #         # TODO: Extract Vendor ID and lookup id
+        #         pass
+
+        # create mapping for VendorLookupId
+        # which is needed to populate a lookup field in SharePoint
+        ven_ids = old_ven[["id", "Vendor ID"]].to_dict("records")
+        old_lookup_ids = {item["Vendor ID"]: item["id"] for item in ven_ids}
+        ven_lookup = {**old_lookup_ids}
+
+        # filter for POs that were closed in CitiBuy since the last run
+        po_closed = old_po[~old_po["Title"].isin(new_po["Title"])].copy()
+        po_closed["Status"] = "3PCO - Closed"
+
+        # filter for POs that were created in CitiBuy since the last run
+        po_created = new_po[~new_po["Title"].isin(old_po["Title"])].copy()
+        po_created["Vendor ID"] = po_created["Vendor ID"].replace(ven_lookup)
+        po_created = po_created.rename(columns={"Vendor ID": "VendorLookupId"})
+
+        # filter for POs that already existed in SharePoint
+        po_exists = new_po[new_po["Title"].isin(old_po["Title"])].copy()
+        po_exists = po_exists.drop(columns="Vendor ID")
+
+        # update closed POs
+        po_closings = BatchedChanges()
+        for po in po_closed.to_dict("records"):
+            po_closings.updates[po["id"]] = {"Status": po["Status"]}
+        print("CLOSINGS")
+        pprint(po_closings.updates)
+
+        # insert new POs
+        po_inserts = BatchedChanges(inserts=po_created.to_dict("records"))
+        print("PO INSERTS")
+        pprint(po_inserts.inserts)
+
+        # update existing POs
+        po_changes = self.detect_changes(
+            old_po.to_dict("records"),
+            po_exists.to_dict("records"),
+            key_col="Title",
+        )
+        print("PO CHANGES")
+        pprint(po_changes.updates)
 
     def detect_changes(
         self,

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+
+CITIBUY = {
+    "po": {
+        "Title": ["P111", "P111:2", "P111:3", "P333"],
+        "PO Number": ["111", "111", "111", "333"],
+        "Release Number": [0, 2, 3, 0],
+        "Vendor ID": ["111", "111", "111", "333"],
+        "Vendor": ["Acme", "Acme", "Acme", "Apple"],
+        "Status": [
+            "3PS - Sent",
+            "3PPR - Partial Receipt",
+            "3PPR - Partial Receipt",
+            "3PS - Sent",
+        ],
+        "PO Type": ["Master Blanket", "Release", "Release", "Open Market"],
+        "Actual Cost": [0, 150, 100, 25],
+        "PO Date": [
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+        ],
+        "Contract Dollar Limit": [0, 150, 100, None],
+        "Contract Amount Spent": [0, 100, 80, None],
+        "Contract Start Date": [
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            None,
+        ],
+        "Contract End Date": [
+            datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
+            None,
+        ],
+    },
+    "vendor": {
+        "Title": ["Acme", "Apple"],
+        "Vendor ID": ["111", "333"],
+        "Point of Contact": ["Alice Williams", "Steve Jobs"],
+        "Email": ["alice@acme.com", "steve@apple.com"],
+        "Phone": ["111-111-1111", "333-333-3333"],
+    },
+}
+
+SHAREPOINT = {
+    "po": {
+        "id": ["1", "2", "3", "4"],
+        "Title": ["P111", "P111:1", "P111:2", "P222"],
+        "PO Number": ["111", "111", "111", "222"],
+        "Release Number": [0, 1, 2, 0],
+        "PO Type": ["Master Blanket", "Release", "Release", "Open Market"],
+        "Vendor ID": ["111", "111", "111", "222"],
+        "Vendor": ["Acme", "Acme", "Acme", "Disney"],
+        "Status": [
+            "3PS - Sent",
+            "3PPR - Partial Receipt",
+            "3PI - In Progress",
+            "3PS - Sent",
+        ],
+        "Actual Cost": [0, 150, 150, 40],
+        "PO Date": [
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+        ],
+        "Contract Dollar Limit": [0, 150, 150, None],
+        "Contract Amount Spent": [0, 100, 100, None],
+        "Contract Start Date": [
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+            None,
+        ],
+        "Contract End Date": [
+            datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
+            None,
+        ],
+    },
+    "vendor": {
+        "id": ["1", "2"],
+        "@odata.etag": ["111", "222"],
+        "Content Type": ["Item", "Item"],
+        "Title": ["Acme", "Disney"],
+        "Attachments": [None, None],
+        "Point of Contact": ["John Doe", "Mickey Mouse"],
+        "Email": ["john@acme.com", "mickey@disney.com"],
+        "Phone": ["111-111-1111", "222-222-2222"],
+        "Vendor ID": ["111", "222"],
+    },
+}

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -30,14 +30,24 @@ class TestContractManagement:
         - The columns of ContractData.po match the CITIBUY constants
         - The columns of ContractData.vendor match the CITIBUY constants
         - The dataframe in ContractData.vendor has been deduped
+        - The PO Type has been set correctly
         """
         # setup
         po_cols = list(constants.CITIBUY["po_cols"].values())
         ven_cols = list(constants.CITIBUY["vendor_cols"].values())
+        po_types = [
+            "Master Blanket",
+            "Release",
+            "Master Blanket",
+            "Release",
+            "Open Market",
+        ]
         # execution
         output = mock_contract.get_citibuy_data()
         df_po = output.po
         df_ven = output.vendor
+        print(df_po.dtypes)
+        print(df_ven.dtypes)
         blanket_title = df_po.loc[0, "Title"]
         release_title = df_po.loc[1, "Title"]
         # validation
@@ -47,6 +57,7 @@ class TestContractManagement:
         assert len(df_ven) == 2
         assert blanket_title == "P111"
         assert release_title == "P111:1"
+        assert list(df_po["PO Type"]) == po_types
 
     def test_get_sharepoint_data(self, mock_contract):
         """Tests the get_sharepoint_data() method executes correctly

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -1,7 +1,10 @@
 import pytest
+import pandas as pd
 
 from dgs_fiscal.etl import ContractManagement
 from dgs_fiscal.etl.contract_management import ContractData, constants
+
+from tests.integration_tests.contract_management import data
 
 
 @pytest.fixture(scope="session", name="mock_contract")
@@ -77,7 +80,28 @@ class TestContractManagement:
         print(output.vendor)
         # validation
         assert isinstance(output, ContractData)
+        assert "id" in output.po.columns
+        assert "id" in output.vendor.columns
         for col in ven_cols:
             assert col in output.vendor.columns
         for col in po_cols:
             assert col in output.po.columns
+
+    def test_reconcile_lists(self, mock_contract):
+        """Tests that the reconcile_lists() method executes correctly
+
+        Validates the following conditions:
+        -
+        """
+        # setup
+        po_citibuy = pd.DataFrame(data.CITIBUY["po"])
+        ven_citibuy = pd.DataFrame(data.CITIBUY["vendor"])
+        po_sharepoint = pd.DataFrame(data.SHAREPOINT["po"])
+        ven_sharepoint = pd.DataFrame(data.SHAREPOINT["vendor"])
+        citibuy = ContractData(po=po_citibuy, vendor=ven_citibuy)
+        sharepoint = ContractData(po=po_sharepoint, vendor=ven_sharepoint)
+        # execution
+        output = mock_contract.update_sharepoint(citibuy, sharepoint)
+        print(output)
+        # validation
+        assert 0


### PR DESCRIPTION
## Summary

Moves functionality scoped in `ContractManagement.reconcile_lists()` to `ContractManagement.update_sharepoint()` and implements that functionality.

Fixes #65 

## Changes Proposed

- Sets "PO Type" column in `ContractManagement.get_citibuy_data()`
- Adds a `ContractManagement.detect_changes()` method which is called by the `ContractManagement.update_sharepoint()`
- Combines `ContractManagement.reconcile_list()` and `ContractManagement.update_sharepoint()`

## Blockers or Questions

- [ ] Haven't yet implemented the direct updates to Sharepoint yet, that is still tracked in #66 

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run integration tests: `pytest tests/integration_tests/contract_management/`
1. Tests should fail on `TestContractManagement.test_reconcile_lists()` to reveal `BatchedChanges` instance
