### PR TITLE
Issue 69 bug lookupid field

### DIFF
--- a/app/src/dgs_fiscal/systems/sharepoint/utils.py
+++ b/app/src/dgs_fiscal/systems/sharepoint/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations  # prevents NameError for typehints
+import re
 
 from dynaconf import Dynaconf
 from O365 import Account
@@ -69,6 +70,10 @@ def col_api_name(columns: dict, col: str, prefix: str = "") -> str:
     if col in columns:
         return prefix + columns[col]
     if col in columns.values():
+        return prefix + col
+    # check if it's a lookup column
+    lookup_col = re.match(r"(\w+)LookupId", col)
+    if lookup_col and lookup_col.group(1) in columns.values():
         return prefix + col
     raise KeyError(
         f"{col} not in the list of cols. "

--- a/app/tests/integration_tests/sharepoint/test_list.py
+++ b/app/tests/integration_tests/sharepoint/test_list.py
@@ -85,6 +85,17 @@ class TestSiteList:
             # cleanup
             assert item.item.delete()
 
+    def test_add_item_lookup(self, test_sharepoint):
+        """Tests that a lookup field is set correctly by add_item() method"""
+        # setup
+        test_data = {"Title": "Lookup", "VendorLookupId": "1"}
+        test_list = test_sharepoint.get_list("API Test")
+        # execution
+        output = test_list.add_item(test_data)
+        pprint(output.fields)
+        # validation
+        assert output.fields["VendorLookupId"] == "1"
+
     def test_add_item_invalid(self, test_list):
         """Tests that add_item() raises a KeyError when it is provided data
         that has a key that isn't one of the list's existing columns

--- a/app/tests/unit_tests/sharepoint/test_utils.py
+++ b/app/tests/unit_tests/sharepoint/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dgs_fiscal.systems.sharepoint.utils import build_filter_str
+from dgs_fiscal.systems.sharepoint.utils import build_filter_str, col_api_name
 
 COLS = {"Text Col": "TextCol", "Num Col": "NumCol"}
 
@@ -45,3 +45,34 @@ def test_build_filter_str_error():
     # execution
     with pytest.raises(KeyError):
         build_filter_str(COLS, input_dict)
+
+
+@pytest.mark.parametrize(
+    "input_col, expected",
+    [
+        ("Text Col", "TextCol"),
+        ("TextCol", "TextCol"),
+        ("TextColLookupId", "TextColLookupId"),
+    ],
+)
+def test_col_api_name(input_col, expected):
+    """Tests that col_api_name() executes successfully
+
+    Validates the following conditions:
+    - Display name passed to function
+    - API name passed to function
+    - LookupId passed to function
+    """
+    # execution
+    output = col_api_name(COLS, input_col)
+    # validation
+    assert output == expected
+
+
+def test_col_api_name_error():
+    """Tests that col_api_name() raises a KeyError if a column name is passed
+    that isn't in the list of columns
+    """
+    # validation
+    with pytest.raises(KeyError):
+        col_api_name(COLS, "fake_col")


### PR DESCRIPTION
## Summary

Fixes bug in `SiteList.add_item()` which prevented users from setting the lookup field by passing `<col_name>LookupId` in the data parameter.

Fixes #69 

## Changes Proposed

- fix(sharepoint): Fixes bug with api_col_name() for lookup cols
- test(sharepoint): Adds test for setting lookup field in add_item() 

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run unit tests: `pytest`
1. Run integration tests for `SiteList`: `pytest tests/integration_tests/sharepoint/test_list.py`