### PR TITLE
Issue 72 segment batch upsert

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -16,3 +16,4 @@ xlwings==0.24.9
 openpyxl==3.0.7
 sqlalchemy==1.4.25
 pyodbc==4.0.32
+more-itertools==8.11.0

--- a/app/setup.py
+++ b/app/setup.py
@@ -18,6 +18,7 @@ setup(
         "selenium",
         "xlwings",
         "openpyxl",
+        "more-itertools",
     ],
     include_package_data=True,
     package_dir={"": "src"},  # this is required to access code in src/

--- a/app/src/dgs_fiscal/systems/sharepoint/list.py
+++ b/app/src/dgs_fiscal/systems/sharepoint/list.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Iterable, Any, Optional
 from dataclasses import dataclass, field
 
 import pandas as pd
+from more_itertools import chunked
 from O365.sharepoint import SharepointList, SharepointListItem
 
 from dgs_fiscal.systems.sharepoint.utils import build_filter_str, col_api_name
@@ -147,7 +148,7 @@ class SiteList:
         Parameters
         ----------
         changes: BatchedChanges
-            Instance of BatchedChanges dataclass which contains the items
+            Instance of the BatchedChanges dataclass which contains the items
             to update or insert into this SharePoint list
 
         Returns
@@ -155,47 +156,63 @@ class SiteList:
         dict
             A dictionary of the JSON response from a batch request
         """
-        batch_url = "https://graph.microsoft.com/v1.0/$batch"
-        base_url = f"/{self.list.main_resource}"
-        requests = []
-        counter = 0
+        results = BatchResults()
 
+        # execute batch updates
         if changes.updates:
-            for item_id, data in changes.updates.items():
-                counter += 1
-                url = base_url + f"/items/{item_id}/fields"
-                request = self._build_request(counter, data, url, "PATCH")
-                requests.append(request)
+            update_batches = chunked(changes.updates.items(), 20)
+            for batch in update_batches:
+                response = self._execute_batch(batch, "PATCH")
+                results.updates.append(response["responses"])
 
+        # execute batch inserts
         if changes.inserts:
-            for data in changes.inserts:
-                counter += 1
-                url = base_url + "/items"
-                request = self._build_request(counter, data, url, "POST")
-                requests.append(request)
+            insert_batches = chunked(changes.inserts, 20)
+            for batch in insert_batches:
+                response = self._execute_batch(batch, "POST")
+                results.inserts.append(response["responses"])
+
+        return results
+
+    def _execute_batch(self, batch: Iterable, method: str) -> dict:
+        """Formats and executes a batch request to Graph API
+
+        Parameters
+        ----------
+        batch: Iterable
+            An iterable of updates or inserts that need to be batched
+        method: str
+            The HTTP method to use for the batch requests
+
+        Returns
+        -------
+        dict
+            Returns a JSON of the response returned by the batch request
+        """
+        batch_url = "https://graph.microsoft.com/v1.0/$batch"
+        base_url = self.list.main_resource
+        counter = 0
+        requests = []
+
+        for item in batch:
+            counter += 1
+            if method == "PATCH":
+                data = self._format_request_data(item[1])
+                url = f"/{base_url}/items/{item[0]}/fields"
+            elif method == "POST":
+                data = {"fields": self._format_request_data(item)}
+                url = f"/{base_url}/items"
+            request = {
+                "id": str(counter),
+                "url": url,
+                "method": method,
+                "body": data,
+                "headers": {"Content-Type": "application/json"},
+            }
+            requests.append(request)
 
         response = self.list.con.post(batch_url, {"requests": requests})
         return response.json()
-
-    def _build_request(
-        self,
-        counter: int,
-        data: dict,
-        url: str,
-        method: str,
-    ) -> dict:
-        """Builds an entry to add to a batch request entry"""
-        request_data = self._format_request_data(data)
-        if method == "POST":
-            request_data = {"fields": request_data}
-        request = {
-            "id": str(counter),
-            "url": url,
-            "method": method,
-            "body": request_data,
-            "headers": {"Content-Type": "application/json"},
-        }
-        return request
 
     def _format_request_data(self, data) -> dict:
         """Get the API col name for each column in the request data"""

--- a/app/src/dgs_fiscal/systems/sharepoint/list.py
+++ b/app/src/dgs_fiscal/systems/sharepoint/list.py
@@ -26,6 +26,22 @@ class BatchedChanges:
     inserts: Optional[List[dict]] = field(default_factory=list)
 
 
+@dataclass
+class BatchResults:
+    """Data class for storing the results to a series of batch requests
+
+    Attributes
+    ----------
+    updates: List[list], optional
+        A list of the JSON responses from each batch update request
+    inserts: List[list], optional
+        A list of the JSON responses from each batch update request
+    """
+
+    updates: Optional[Dict[dict]] = field(default_factory=list)
+    inserts: Optional[List[dict]] = field(default_factory=list)
+
+
 class SiteList:
     """Creates an API client for making calls to the SharePoint list resource
 

--- a/app/tests/integration_tests/sharepoint/test_list.py
+++ b/app/tests/integration_tests/sharepoint/test_list.py
@@ -119,11 +119,13 @@ class TestSiteList:
         changes = BatchedChanges(updates=updates, inserts=inserts)
         # execution
         results = test_list.batch_upsert(changes)
-        pprint(results)
+        updates = results.updates
+        inserts = results.inserts
         # validation
-        for request in results["responses"]:
-            assert request["status"] in (200, 201)
-            assert "id" in request["body"]
+        for batch in updates + inserts:
+            for request in batch:
+                assert request["status"] in (200, 201)
+                assert "id" in request["body"]
 
 
 class TestItemCollection:


### PR DESCRIPTION
## Summary

Segments the `SiteList.batch_upsert()` updates and inserts into batches of 20, which is the max batch size that Graph API supports

Fixes #72 

## Changes Proposed

- build: Adds more-itertools as a project dependency
- feat(sharepoint): Adds `BatchResults` dataclass to use as a return type for `SiteList.batch_upsert()`
- refactor(sharepoint): Change `SiteList.batch_upsert()` execution strategy and return type

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the SharePoint integration tests: `pytest tests/integration_tests/sharepoint/`
1. All tests should pass
