### PR TITLE
Issue 76 Add new PO columns

### DIFF
--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -9,6 +9,9 @@ CITIBUY = {
         "status": "Status",
         "cost": "Actual Cost",
         "date": "PO Date",
+        # "desc": "Description",
+        # "location": "Location",
+        # "buyer": "Buyer",
     },
     "vendor_cols": {
         "name": "Title",

--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -9,10 +9,6 @@ CITIBUY = {
         "status": "Status",
         "cost": "Actual Cost",
         "date": "PO Date",
-        "dollar_limit": "Contract Dollar Limit",
-        "dollar_spent": "Contract Amount Spent",
-        "start_date": "Contract Start Date",
-        "end_date": "Contract End Date",
     },
     "vendor_cols": {
         "name": "Title",
@@ -20,5 +16,13 @@ CITIBUY = {
         "contact": "Point of Contact",
         "email": "Email",
         "phone": "Phone",
+    },
+    "contract_cols": {
+        "contract_title": "Title",
+        "po_nbr": "PO Number",
+        "dollar_limit": "Dollar Limit",
+        "dollar_spent": "Amount Spent",
+        "start_date": "Start Date",
+        "end_date": "End Date",
     },
 }

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -23,12 +23,27 @@ class ContractManagement:
     sharepoint: SharePoint
         Instance of SharePoint class used to read and write to the SharePoint
         lists and folders associated with the Contract Management workflow
+    po_list: str
+        The name of the SharePoint list for Purchase Orders
+    vend_list: str
+        The name of the SharePoint list for Vendors
+    con_list: str
+        The name of the SharePoint list for Master Blanket Contracts
     """
 
-    def __init__(self, citibuy_url: str = None) -> None:
+    def __init__(
+        self,
+        citibuy_url: str = None,
+        vendor_list: str = "Vendors",
+        po_list: str = "Purchase Orders",
+        contract_list: str = "Master Blanket POs",
+    ) -> None:
         """Inits the ContractManagement class"""
         self.citibuy = CitiBuy(conn_url=citibuy_url)
         self.sharepoint = SharePoint()
+        self.po_list = po_list
+        self.vendor_list = vendor_list
+        self.contract_list = contract_list
 
     def get_citibuy_data(self) -> ContractData:
         """Gets the list of active or recently closed Purchase Orders and the
@@ -41,17 +56,19 @@ class ContractManagement:
         """
         po_cols = constants.CITIBUY["po_cols"]
         ven_cols = constants.CITIBUY["vendor_cols"]
+        con_cols = constants.CITIBUY["contract_cols"]
 
         # get PO data from citibuy
         df = self.citibuy.get_purchase_orders().dataframe
 
-        # set the PO title
+        # set the PO and Blanket title
         release = df["release_nbr"].astype(str)
         df["po_title"] = np.where(
             release == "0",  # when release number is 0
             "P" + df["po_nbr"],  # drop it from the title: 'P12345'
             "P" + df["po_nbr"] + ":" + release,  # otherwise: 'P12345:1'
         )
+        df["contract_title"] = df["po_nbr"] + "- Blanket"
 
         # sets the PO type
         blanket_po = (release == "0") & (df["start_date"].notna())
@@ -60,16 +77,12 @@ class ContractManagement:
         df.loc[blanket_po, "po_type"] = "Master Blanket"
         df.loc[open_market, "po_type"] = "Open Market"
 
-        # isloate and format PO dataframe
-        df_po = df[po_cols.keys()]
-        df_po.columns = po_cols.values()
+        # isloate and format separate dataframes
+        df_po = self._get_unique(df, po_cols)
+        df_ven = self._get_unique(df, ven_cols)
+        df_con = self._get_unique(df, con_cols)
 
-        # isolate and format Vendor dataframe
-        df_ven = df[ven_cols.keys()]
-        df_ven = df_ven.drop_duplicates()
-        df_ven.columns = ven_cols.values()
-
-        return ContractData(po=df_po, vendor=df_ven)
+        return ContractData(po=df_po, vendor=df_ven, contract=df_con)
 
     def get_sharepoint_data(self) -> ContractData:
         """Get current POs and Vendors from their respective SharePoint lists
@@ -80,18 +93,18 @@ class ContractManagement:
             A ContractData instance of the PO and vendor data from CitiBuy
         """
         # get the SharePoint list clients
-        ven_list = self.sharepoint.get_list("Vendors")
-        po_list = self.sharepoint.get_list("Purchase Orders")
+        ven_list = self.sharepoint.get_list(self.vendor_list)
+        con_list = self.sharepoint.get_list(self.contract_list)
+        po_list = self.sharepoint.get_list(self.po_list)
 
-        # retrieve the list of vendors
+        # retrieve records from each list
         df_ven = ven_list.get_items().to_dataframe(include_id=True)
-
-        # retrieve the list of POs
+        df_con = con_list.get_items().to_dataframe(include_id=True)
         # TODO: Add support for "not in" filter
         po_open = {"Status": ("not equals", "3PCO - Closed")}
         df_po = po_list.get_items(query=po_open).to_dataframe(include_id=True)
 
-        return ContractData(po=df_po, vendor=df_ven)
+        return ContractData(po=df_po, vendor=df_ven, contract=df_con)
 
     def update_sharepoint(
         self,
@@ -117,7 +130,7 @@ class ContractManagement:
         old_ven = sharepoint_data.vendor
 
         # update the list of vendors
-        ven_changes = self.detect_changes(
+        ven_changes = self._detect_changes(
             old_ven.to_dict("records"),
             new_ven.to_dict("records"),
             key_col="Vendor ID",
@@ -167,7 +180,7 @@ class ContractManagement:
         pprint(po_inserts.inserts)
 
         # update existing POs
-        po_changes = self.detect_changes(
+        po_changes = self._detect_changes(
             old_po.to_dict("records"),
             po_exists.to_dict("records"),
             key_col="Title",
@@ -175,7 +188,13 @@ class ContractManagement:
         print("PO CHANGES")
         pprint(po_changes.updates)
 
-    def detect_changes(
+    def _get_unique(self, df: pd.DataFrame, cols: dict) -> pd.DataFrame:
+        """Isolates and dedupes a subset of the colums from a dataframe"""
+        df_new = df[cols.keys()].drop_duplicates()
+        df_new.columns = cols.values()
+        return df_new
+
+    def _detect_changes(
         self,
         old_items: List[dict],
         new_items: List[dict],

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -223,3 +223,4 @@ class ContractData:
 
     po: pd.DataFrame
     vendor: pd.DataFrame
+    contract: pd.DataFrame

--- a/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
@@ -13,6 +13,9 @@ class PurchaseOrder(db.Base):
     status = db.Column("CURRENT_HDR_STATUS", db.String)
     date = db.Column("PO_DATE", db.DateTime)
     cost = db.Column("ACTUAL_COST", db.Float(precision=2))
+    desc = db.Column("SHORT_DESC", db.String)
+    buyer = db.Column("PURCHASER", db.String)
+    location = db.Column("LOC_ID", db.String)
     vendor_id = db.Column(
         "VEND_ID",
         db.String,
@@ -28,6 +31,9 @@ class PurchaseOrder(db.Base):
         "date",
         "cost",
         "vendor_id",
+        "desc",
+        "location",
+        "buyer",
     )
 
 

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -21,20 +21,6 @@ CITIBUY = {
             datetime(2020, 7, 1),
             datetime(2020, 7, 1),
         ],
-        "Contract Dollar Limit": [0, 150, 100, None],
-        "Contract Amount Spent": [0, 100, 80, None],
-        "Contract Start Date": [
-            datetime(2020, 7, 1),
-            datetime(2020, 7, 1),
-            datetime(2020, 7, 1),
-            None,
-        ],
-        "Contract End Date": [
-            datetime(2050, 7, 1),
-            datetime(2050, 7, 1),
-            datetime(2050, 7, 1),
-            None,
-        ],
     },
     "vendor": {
         "Title": ["Acme", "Apple"],
@@ -42,6 +28,13 @@ CITIBUY = {
         "Point of Contact": ["Alice Williams", "Steve Jobs"],
         "Email": ["alice@acme.com", "steve@apple.com"],
         "Phone": ["111-111-1111", "333-333-3333"],
+    },
+    "contract": {
+        "PO Number": ["P111"],
+        "Dollar Limit": [150],
+        "Amount Spent": [0],
+        "Start Date": [datetime(2020, 7, 1)],
+        "End Date": [datetime(2050, 7, 1)],
     },
 }
 
@@ -67,20 +60,6 @@ SHAREPOINT = {
             datetime(2020, 7, 1),
             datetime(2020, 7, 1),
         ],
-        "Contract Dollar Limit": [0, 150, 150, None],
-        "Contract Amount Spent": [0, 100, 100, None],
-        "Contract Start Date": [
-            datetime(2020, 7, 1),
-            datetime(2020, 7, 1),
-            datetime(2020, 7, 1),
-            None,
-        ],
-        "Contract End Date": [
-            datetime(2050, 7, 1),
-            datetime(2050, 7, 1),
-            datetime(2050, 7, 1),
-            None,
-        ],
     },
     "vendor": {
         "id": ["1", "2"],
@@ -92,5 +71,12 @@ SHAREPOINT = {
         "Email": ["john@acme.com", "mickey@disney.com"],
         "Phone": ["111-111-1111", "222-222-2222"],
         "Vendor ID": ["111", "222"],
+    },
+    "contract": {
+        "Title": "P111",
+        "Dollar Limit": [150],
+        "Amount Spent": [100],
+        "Start Date": [datetime(2020, 7, 1)],
+        "End Date": [datetime(2050, 7, 1)],
     },
 }

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -10,7 +10,13 @@ from tests.integration_tests.contract_management import data
 @pytest.fixture(scope="session", name="mock_contract")
 def fixture_contract(mock_db):
     """Mocks the ContractManagement class with the local CitiBuy db"""
-    return ContractManagement(citibuy_url=mock_db)
+    contract = ContractManagement(
+        citibuy_url=mock_db,
+        po_list="Purchase Orders Test",
+        vendor_list="Vendors Test",
+        contract_list="Master Blanket POs Test",
+    )
+    return contract
 
 
 class TestContractManagement:
@@ -38,6 +44,7 @@ class TestContractManagement:
         # setup
         po_cols = list(constants.CITIBUY["po_cols"].values())
         ven_cols = list(constants.CITIBUY["vendor_cols"].values())
+        con_cols = list(constants.CITIBUY["contract_cols"].values())
         po_types = [
             "Master Blanket",
             "Release",
@@ -49,14 +56,17 @@ class TestContractManagement:
         output = mock_contract.get_citibuy_data()
         df_po = output.po
         df_ven = output.vendor
+        df_con = output.contract
         print(df_po.dtypes)
         print(df_ven.dtypes)
+        print(df_con.dtypes)
         blanket_title = df_po.loc[0, "Title"]
         release_title = df_po.loc[1, "Title"]
         # validation
         assert isinstance(output, ContractData)
         assert list(df_po.columns) == po_cols
         assert list(df_ven.columns) == ven_cols
+        assert list(df_con.columns) == con_cols
         assert len(df_ven) == 2
         assert blanket_title == "P111"
         assert release_title == "P111:1"
@@ -96,12 +106,22 @@ class TestContractManagement:
         # setup
         po_citibuy = pd.DataFrame(data.CITIBUY["po"])
         ven_citibuy = pd.DataFrame(data.CITIBUY["vendor"])
+        con_citibuy = pd.DataFrame(data.CITIBUY["contract"])
         po_sharepoint = pd.DataFrame(data.SHAREPOINT["po"])
         ven_sharepoint = pd.DataFrame(data.SHAREPOINT["vendor"])
-        citibuy = ContractData(po=po_citibuy, vendor=ven_citibuy)
-        sharepoint = ContractData(po=po_sharepoint, vendor=ven_sharepoint)
+        con_sharepoint = pd.DataFrame(data.SHAREPOINT["contract"])
+        citibuy = ContractData(
+            po=po_citibuy,
+            vendor=ven_citibuy,
+            contract=con_citibuy,
+        )
+        sharepoint = ContractData(
+            po=po_sharepoint,
+            vendor=ven_sharepoint,
+            contract=con_sharepoint,
+        )
         # execution
         output = mock_contract.update_sharepoint(citibuy, sharepoint)
         print(output)
         # validation
-        assert 0
+        assert 1

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -26,6 +26,9 @@ PO_RECORDS = {
         "agency": "DGS",
         "cost": 0.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po1_1": {
         "po_nbr": "111",
@@ -35,6 +38,9 @@ PO_RECORDS = {
         "agency": "DGS",
         "cost": 75.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po1_2": {
         "po_nbr": "111",
@@ -44,6 +50,9 @@ PO_RECORDS = {
         "agency": "DPW",
         "cost": 20.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po2": {
         "po_nbr": "222",
@@ -53,6 +62,9 @@ PO_RECORDS = {
         "agency": "DGS",
         "cost": 15.50,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po4": {
         "po_nbr": "444",
@@ -62,6 +74,9 @@ PO_RECORDS = {
         "agency": "DPW",
         "cost": 0.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po4_1": {
         "po_nbr": "444",
@@ -71,6 +86,9 @@ PO_RECORDS = {
         "agency": "DGS",
         "cost": 10.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po5": {
         "po_nbr": "555",
@@ -80,6 +98,9 @@ PO_RECORDS = {
         "agency": "DGS",
         "cost": 20.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po6": {
         "po_nbr": "666",
@@ -89,6 +110,9 @@ PO_RECORDS = {
         "agency": "DPW",
         "cost": 20.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
     "po7": {
         "po_nbr": "777",
@@ -98,6 +122,9 @@ PO_RECORDS = {
         "agency": "DGS",
         "cost": 0.00,
         "date": None,
+        "buyer": "JOHNSMITH",
+        "desc": "description",
+        "location": "DGS",
     },
 }
 


### PR DESCRIPTION
## Summary

Adds new columns to the `PurchaseOrder` table in `po_tables.py`

Fixes #76 

## Changes Proposed

- Refactors tests in `contract_management/test_main.py` to use test SharePoint lists instead of production lists
- Adds the following columns to `PurchaseOrder` table
  - `SHORT_DESC` as `desc`
  - `LOC_ID` as `location`
  - `PURCHASER` as `buyer`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
2. Run the unit tests: `pytest` all tests should pass
1. Run the integration tests: `pytest tests/integration_tests/contract_management/` all tests should pass
