### PR TITLE
Issue 68 Adds `Address` cols to `get_purchase_orders()`

### DIFF
--- a/app/src/dgs_fiscal/systems/citibuy/models/__init__.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/__init__.py
@@ -6,4 +6,8 @@ from dgs_fiscal.systems.citibuy.models.po_tables import (
     PurchaseOrder,
     BlanketContract,
 )
-from dgs_fiscal.systems.citibuy.models.vendor_tables import Vendor
+from dgs_fiscal.systems.citibuy.models.vendor_tables import (
+    Vendor,
+    VendorAddress,
+    Address,
+)

--- a/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
@@ -9,12 +9,50 @@ class Vendor(db.Base):
     # columns
     vendor_id = db.Column("VENDOR_NBR", db.String, primary_key=True)
     name = db.Column("NAME", db.String)
-    contact = db.Column("EMA_CONTACT_NAME", db.String)
-    email = db.Column("EMA_EMAIL", db.String)
-    phone = db.Column("EMA_PHONE", db.String)
+    emg_contact = db.Column("EMA_CONTACT_NAME", db.String)
+    emg_email = db.Column("EMA_EMAIL", db.String)
+    emg_phone = db.Column("EMA_PHONE", db.String)
 
     # relationships
     purchase_orders = db.relationship("PurchaseOrder", backref="vendor")
 
     # column list for querying
-    columns = ("name", "contact", "email", "phone")
+    columns = ("name", "emg_contact", "emg_email", "emg_phone")
+
+
+class VendorAddress(db.Base):
+    """Association table between Vendor and Address"""
+
+    __tablename__ = "VENDOR_ADDRESS"
+
+    # columns
+    address_id = db.Column(
+        "ADDR_ID",
+        db.String,
+        db.ForeignKey("ADDRESS.ADDR_ID"),
+        primary_key=True,
+    )
+    vendor_id = db.Column(
+        "VENDOR_NBR",
+        db.String,
+        db.ForeignKey("VENDOR.VENDOR_NBR"),
+        primary_key=True,
+    )
+    address_type = db.Column("ADDRESS_TYPE_REF", db.String, primary_key=True)
+    default = db.Column("DEFAULT_ADDRESS_FOR_TYPE", db.String)
+
+    # relationships
+    vendor = db.relationship("Vendor", backref="addresses")
+    address = db.relationship("Address", backref="vendor")
+
+
+class Address(db.Base):
+    """Table that stores the mailing addresses for Vendors"""
+
+    __tablename__ = "ADDRESS"
+
+    # columns
+    address_id = db.Column("ADDR_ID", db.String, primary_key=True)
+    contact = db.Column("CONTACT", db.String)
+    phone = db.Column("PH_NBR", db.String)
+    email = db.Column("INTERNET_ADDRESS", db.String)

--- a/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
@@ -56,3 +56,6 @@ class Address(db.Base):
     contact = db.Column("CONTACT", db.String)
     phone = db.Column("PH_NBR", db.String)
     email = db.Column("INTERNET_ADDRESS", db.String)
+
+    # column list for query
+    columns = ("address_id", "contact", "phone", "email")

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -20,7 +20,7 @@ VENDORS = {
 VEN_ADDRESS = {
     "acme_mail": {
         "vendor_id": "111",
-        "address_id": "222",
+        "address_id": "111",
         "address_type": "M",
         "default": "Y",
     },
@@ -293,13 +293,34 @@ CONTRACTS = {
 }
 
 PO_RESULTS = [
-    {**CONTRACTS["blanket1_DGS"], **PO_RECORDS["po1"], **VENDORS["acme"]},
-    {**CONTRACTS["blanket1_DGS"], **PO_RECORDS["po1_1"], **VENDORS["acme"]},
-    {**CONTRACTS["blanket4"], **PO_RECORDS["po4"], **VENDORS["disney"]},
-    {**CONTRACTS["blanket4"], **PO_RECORDS["po4_1"], **VENDORS["disney"]},
+    {
+        **CONTRACTS["blanket1_DGS"],
+        **PO_RECORDS["po1"],
+        **VENDORS["acme"],
+        **ADDRESSES["acme_mail"],
+    },
+    {
+        **CONTRACTS["blanket1_DGS"],
+        **PO_RECORDS["po1_1"],
+        **VENDORS["acme"],
+        **ADDRESSES["acme_mail"],
+    },
+    {
+        **CONTRACTS["blanket4"],
+        **PO_RECORDS["po4"],
+        **VENDORS["disney"],
+        **ADDRESSES["disney_mail"],
+    },
+    {
+        **CONTRACTS["blanket4"],
+        **PO_RECORDS["po4_1"],
+        **VENDORS["disney"],
+        **ADDRESSES["disney_mail"],
+    },
     {
         **PO_RECORDS["po5"],
         **VENDORS["acme"],
+        **ADDRESSES["acme_mail"],
         "contract_agency": None,
         "start_date": None,
         "end_date": None,

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -4,13 +4,55 @@ VENDORS = {
     "acme": {
         "vendor_id": "111",
         "name": "Acme",
-        "contact": "Jane Doe",
-        "email": "jane.doe@acme.com",
-        "phone": "(111) 111-1111",
+        "emg_contact": "Jane Doe",
+        "emg_email": "jane.doe@acme.com",
+        "emg_phone": "(111) 111-1111",
     },
     "disney": {
         "vendor_id": "222",
         "name": "Disney",
+        "emg_contact": "Anthony Williams",
+        "emg_email": "anthony.williams@disney.com",
+        "emg_phone": "(222) 222-2222",
+    },
+}
+
+VEN_ADDRESS = {
+    "acme_mail": {
+        "vendor_id": "111",
+        "address_id": "222",
+        "address_type": "M",
+        "default": "Y",
+    },
+    "acme_extra": {
+        "vendor_id": "111",
+        "address_id": "222",
+        "address_type": "R",
+        "default": "Y",
+    },
+    "disney": {
+        "vendor_id": "222",
+        "address_id": "333",
+        "address_type": "M",
+        "default": "Y",
+    },
+}
+
+ADDRESSES = {
+    "acme_mail": {
+        "address_id": "111",
+        "contact": "Jane Doe",
+        "email": "jane.doe@acme.com",
+        "phone": "(111) 111-1111",
+    },
+    "acme_extra": {
+        "address_id": "222",
+        "contact": "John Doe",
+        "email": "john.doe@acme.com",
+        "phone": "(111) 111-1111",
+    },
+    "disney_mail": {
+        "address_id": "333",
         "contact": "Anthony Williams",
         "email": "anthony.williams@disney.com",
         "phone": "(222) 222-2222",

--- a/app/tests/utils/populate_citibuy_db.py
+++ b/app/tests/utils/populate_citibuy_db.py
@@ -33,8 +33,14 @@ def populate_db(session: Session) -> None:
     pos = [models.PurchaseOrder(**po) for po in data.PO_RECORDS.values()]
     invoices = [models.Invoice(**inv) for inv in data.INVOICES.values()]
     contracts = [models.BlanketContract(**c) for c in data.CONTRACTS.values()]
+    addresses = [models.Address(**a) for a in data.ADDRESSES.values()]
+    vendor_addresses = [
+        models.VendorAddress(**va) for va in data.VEN_ADDRESS.values()
+    ]
     add_to_session(session, vendors)
     add_to_session(session, pos)
     add_to_session(session, invoices)
     add_to_session(session, contracts)
+    add_to_session(session, addresses)
+    add_to_session(session, vendor_addresses)
     session.commit()


### PR DESCRIPTION
## Summary

Creates `VendorAddress` and `Address` models in `vendor_tables.py` and adds columns from the `Address` model to the result returned from `CitiBuy.get_purchase_orders()`

Fixes #68 

## Changes Proposed

- Creates `Address` and `VendorAddress` models in `vendor_tables.py`
- Adds dummy data for `Address` and `VendorAddress` to `citibuy_data.py`
- Includes `email`, `contact`, and `phone` from `Address` model in the result from `CitiBuy.get_purchase_orders()`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the unit tests: `pytest`
1. All unit tests should pass
