### PR TITLE
Issue 82 update contract list

### DIFF
--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -4,8 +4,7 @@ CITIBUY = {
         "po_nbr": "PO Number",
         "release_nbr": "Release Number",
         "po_type": "PO Type",
-        "vendor_id": "Vendor ID",
-        "name": "Vendor",
+        "vendor_id": "Vendor",
         "status": "Status",
         "cost": "Actual Cost",
         "date": "PO Date",
@@ -24,11 +23,11 @@ CITIBUY = {
         "emg_phone": "Emergency Phone",
     },
     "contract_cols": {
-        "contract_title": "Title",
-        "po_nbr": "PO Number",
+        "po_nbr": "Title",
         "dollar_limit": "Dollar Limit",
         "dollar_spent": "Amount Spent",
         "start_date": "Start Date",
         "end_date": "End Date",
+        "vendor_id": "Vendor",
     },
 }

--- a/app/src/dgs_fiscal/systems/sharepoint/__init__.py
+++ b/app/src/dgs_fiscal/systems/sharepoint/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ["SharePoint", "BatchedChanges"]
 
 from dgs_fiscal.systems.sharepoint.client import SharePoint
-from dgs_fiscal.systems.sharepoint.list import BatchedChanges
+from dgs_fiscal.systems.sharepoint.list import BatchedChanges, BatchResults

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -2,20 +2,27 @@ from datetime import datetime
 
 CITIBUY = {
     "po": {
-        "Title": ["P111", "P111:2", "P111:3", "P333"],
-        "PO Number": ["111", "111", "111", "333"],
-        "Release Number": [0, 2, 3, 0],
-        "Vendor ID": ["111", "111", "111", "333"],
-        "Vendor": ["Acme", "Acme", "Acme", "Apple"],
+        "Title": ["P111", "P111:2", "P111:3", "P333", "P444"],
+        "PO Number": ["111", "111", "111", "333", "333"],
+        "Release Number": [0, 2, 3, 0, 0],
+        "PO Type": [
+            "Master Blanket",
+            "Release",
+            "Release",
+            "Open Market",
+            "Master Blanket",
+        ],
+        "Vendor": ["111", "111", "111", "333", "333"],
         "Status": [
             "3PS - Sent",
             "3PPR - Partial Receipt",
             "3PPR - Partial Receipt",
             "3PS - Sent",
+            "3PS - Sent",
         ],
-        "PO Type": ["Master Blanket", "Release", "Release", "Open Market"],
-        "Actual Cost": [0, 150, 100, 25],
+        "Actual Cost": [0, 150, 100, 25, 0],
         "PO Date": [
+            datetime(2020, 7, 1),
             datetime(2020, 7, 1),
             datetime(2020, 7, 1),
             datetime(2020, 7, 1),
@@ -30,11 +37,12 @@ CITIBUY = {
         "Phone": ["111-111-1111", "333-333-3333"],
     },
     "contract": {
-        "PO Number": ["P111"],
-        "Dollar Limit": [150],
-        "Amount Spent": [0],
-        "Start Date": [datetime(2020, 7, 1)],
-        "End Date": [datetime(2050, 7, 1)],
+        "Title": ["P111", "333"],
+        "Dollar Limit": [150, 200],
+        "Amount Spent": [125, 0],
+        "Start Date": [datetime(2020, 7, 1), datetime(2020, 7, 1)],
+        "End Date": [datetime(2050, 7, 1), datetime(2050, 7, 1)],
+        "Vendor": ["111", "333"],
     },
 }
 
@@ -44,8 +52,7 @@ SHAREPOINT = {
         "Title": ["P111", "P111:1", "P111:2", "P222"],
         "PO Number": ["111", "111", "111", "222"],
         "Release Number": [0, 1, 2, 0],
-        "PO Type": ["Master Blanket", "Release", "Release", "Open Market"],
-        "Vendor ID": ["111", "111", "111", "222"],
+        "PO Type": ["Master Blanket", "Release", "Release", "Master Blanket"],
         "Vendor": ["Acme", "Acme", "Acme", "Disney"],
         "Status": [
             "3PS - Sent",
@@ -73,10 +80,12 @@ SHAREPOINT = {
         "Vendor ID": ["111", "222"],
     },
     "contract": {
-        "Title": "P111",
-        "Dollar Limit": [150],
-        "Amount Spent": [100],
-        "Start Date": [datetime(2020, 7, 1)],
-        "End Date": [datetime(2050, 7, 1)],
+        "id": ["1", "2"],
+        "Title": ["P111", "P222"],
+        "Dollar Limit": [150, 100],
+        "Amount Spent": [100, 100],
+        "Start Date": [datetime(2020, 7, 1), datetime(2020, 7, 1)],
+        "End Date": [datetime(2050, 7, 1), datetime(2050, 7, 1)],
+        "Vendor": ["Acme", "Disney"],
     },
 }

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -37,7 +37,7 @@ CITIBUY = {
         "Phone": ["111-111-1111", "333-333-3333"],
     },
     "contract": {
-        "Title": ["P111", "333"],
+        "Title": ["P111", "P333"],
         "Dollar Limit": [150, 200],
         "Amount Spent": [125, 0],
         "Start Date": [datetime(2020, 7, 1), datetime(2020, 7, 1)],

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -6,6 +6,10 @@ from dgs_fiscal.etl.contract_management import ContractData, constants
 
 from tests.integration_tests.contract_management import data
 
+PO_COLS = list(constants.CITIBUY["po_cols"].values())
+VEN_COLS = list(constants.CITIBUY["vendor_cols"].values())
+CON_COLS = list(constants.CITIBUY["contract_cols"].values())
+
 
 @pytest.fixture(scope="session", name="mock_contract")
 def fixture_contract(mock_db):
@@ -42,9 +46,6 @@ class TestContractManagement:
         - The PO Type has been set correctly
         """
         # setup
-        po_cols = list(constants.CITIBUY["po_cols"].values())
-        ven_cols = list(constants.CITIBUY["vendor_cols"].values())
-        con_cols = list(constants.CITIBUY["contract_cols"].values())
         po_types = [
             "Master Blanket",
             "Release",
@@ -64,9 +65,9 @@ class TestContractManagement:
         release_title = df_po.loc[1, "Title"]
         # validation
         assert isinstance(output, ContractData)
-        assert list(df_po.columns) == po_cols
-        assert list(df_ven.columns) == ven_cols
-        assert list(df_con.columns) == con_cols
+        assert list(df_po.columns) == PO_COLS
+        assert list(df_ven.columns) == VEN_COLS
+        assert list(df_con.columns) == CON_COLS
         assert len(df_ven) == 2
         assert blanket_title == "P111"
         assert release_title == "P111:1"
@@ -80,10 +81,6 @@ class TestContractManagement:
         - The Vendor column in the PO data has been matched with Vendor ID
         - The names of the columns match the output of get_citibuy_data()
         """
-        # setup
-        po_cols = list(constants.CITIBUY["po_cols"].values())
-        ven_cols = list(constants.CITIBUY["vendor_cols"].values())
-        po_cols.remove("Vendor ID")
         # execution
         output = mock_contract.get_sharepoint_data()
         print(output.po)
@@ -92,9 +89,9 @@ class TestContractManagement:
         assert isinstance(output, ContractData)
         assert "id" in output.po.columns
         assert "id" in output.vendor.columns
-        for col in ven_cols:
+        for col in VEN_COLS:
             assert col in output.vendor.columns
-        for col in po_cols:
+        for col in PO_COLS:
             assert col in output.po.columns
 
 


### PR DESCRIPTION
## Summary

Implements the `ContractManagement.update_contract_list()`

Fixes #82 

## Changes Proposed

- Implements the `ContractManagement.update_contract_list()` method
- Adds a `ContractManagement._map_lookup_ids()` helper method
- Changes the name of the constants in `contract_management/constants.py` to simplify the `update_contract_list()` method

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the integration tests: `pytest tests/integration_tests/contract_management/`
1. All tests should pass
