### PR TITLE
Issue 84 `update_po_list()`

### DIFF
--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -3,7 +3,7 @@ from datetime import datetime
 CITIBUY = {
     "po": {
         "Title": ["P111", "P111:2", "P111:3", "P333", "P444"],
-        "PO Number": ["111", "111", "111", "333", "333"],
+        "PO Number": ["P111", "P111", "P111", "P333", "P444"],
         "Release Number": [0, 2, 3, 0, 0],
         "PO Type": [
             "Master Blanket",

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -25,7 +25,6 @@ def fixture_contract(mock_db):
     return contract
 
 
-@pytest.mark.skip
 class TestContractManagement:
     """Tests the ContractManagement class methods"""
 
@@ -105,7 +104,6 @@ class TestUpdateLists:
     for Vendors, Contracts, and Purchase Orders
     """
 
-    @pytest.mark.skip
     def test_update_vendor_list(self, mock_contract):
         """Tests that the update_vendor_list() method executes correctly
 
@@ -132,6 +130,15 @@ class TestUpdateLists:
           inserts
         """
         # setup - create dummy data
+        po_mapping = {
+            "P111",
+            "P111:1",
+            "P111:2",
+            "P222",
+            "P444",
+            "P111:3",
+            "P333",
+        }
         citibuy = pd.DataFrame(data.CITIBUY["po"])
         sharepoint = pd.DataFrame(data.SHAREPOINT["po"])
         # setup - make sure dummy cols match constants
@@ -139,9 +146,17 @@ class TestUpdateLists:
         for col in PO_COLS:
             assert col in sharepoint.columns
         # execution
-        mock_contract.update_po_list(sharepoint, citibuy, VEN_MAPPING)
+        output = mock_contract.update_po_list(
+            sharepoint,
+            citibuy,
+            VEN_MAPPING,
+            CON_MAPPING,
+        )
+        print(output)
         # validation
-        assert 0
+        assert set(output.keys()) == po_mapping
+        for po_nbr in ["P111:3", "P333", "P444"]:
+            assert output.get(po_nbr) is not None
 
     def test_update_contract_list(self, mock_contract):
         """Tests that the update_contract_list() method executes correctly

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -61,7 +61,7 @@ ADDRESSES = {
 
 PO_RECORDS = {
     "po1": {
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 0,
         "vendor_id": "111",
         "status": "3PS",
@@ -73,7 +73,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po1_1": {
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 1,
         "vendor_id": "111",
         "status": "3PPR",
@@ -85,7 +85,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po1_2": {
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 2,
         "vendor_id": "222",
         "status": "3PPR",
@@ -97,7 +97,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po2": {
-        "po_nbr": "222",
+        "po_nbr": "P222",
         "release_nbr": 0,
         "vendor_id": "222",
         "status": "3PCO",
@@ -109,7 +109,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po4": {
-        "po_nbr": "444",
+        "po_nbr": "P444",
         "release_nbr": 0,
         "vendor_id": "222",
         "status": "3PS",
@@ -121,7 +121,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po4_1": {
-        "po_nbr": "444",
+        "po_nbr": "P444",
         "release_nbr": 1,
         "vendor_id": "222",
         "status": "3PPR",
@@ -133,7 +133,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po5": {
-        "po_nbr": "555",
+        "po_nbr": "P555",
         "release_nbr": 0,
         "vendor_id": "111",
         "status": "3PS",
@@ -145,7 +145,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po6": {
-        "po_nbr": "666",
+        "po_nbr": "P666",
         "release_nbr": 0,
         "vendor_id": "111",
         "status": "3PS",
@@ -157,7 +157,7 @@ PO_RECORDS = {
         "location": "DGS",
     },
     "po7": {
-        "po_nbr": "777",
+        "po_nbr": "P777",
         "release_nbr": 0,
         "vendor_id": "222",
         "status": "3PCO",
@@ -173,7 +173,7 @@ PO_RECORDS = {
 INVOICES = {
     "inv1": {
         "id": "invoice1",
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 1,
         "vendor_id": "111",
         "invoice_number": "Invoice#1",
@@ -183,7 +183,7 @@ INVOICES = {
     },
     "inv2": {
         "id": "invoice2",
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 1,
         "vendor_id": "111",
         "invoice_number": "Invoice#2",
@@ -193,7 +193,7 @@ INVOICES = {
     },
     "inv3": {
         "id": "invoice3",
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 1,
         "vendor_id": "111",
         "invoice_number": "Invoice#2",
@@ -203,7 +203,7 @@ INVOICES = {
     },
     "inv4": {
         "id": "invoice4",
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 1,
         "vendor_id": "111",
         "invoice_number": "Invoice#3",
@@ -213,7 +213,7 @@ INVOICES = {
     },
     "disney_inv5": {
         "id": "invoice5",
-        "po_nbr": "222",
+        "po_nbr": "P222",
         "release_nbr": 0,
         "vendor_id": "222",
         "invoice_number": "#1",
@@ -223,7 +223,7 @@ INVOICES = {
     },
     "disney_inv6": {
         "id": "invoice6",
-        "po_nbr": "222",
+        "po_nbr": "P222",
         "release_nbr": 0,
         "vendor_id": "222",
         "invoice_number": "#2",
@@ -233,7 +233,7 @@ INVOICES = {
     },
     "disney_inv7": {
         "id": "invoice7",
-        "po_nbr": "333",
+        "po_nbr": "P333",
         "release_nbr": 0,
         "vendor_id": "222",
         "invoice_number": "#3",
@@ -243,7 +243,7 @@ INVOICES = {
     },
     "disney_inv8": {
         "id": "invoice8",
-        "po_nbr": "444",
+        "po_nbr": "P444",
         "release_nbr": 1,
         "vendor_id": "222",
         "invoice_number": "#4",
@@ -255,7 +255,7 @@ INVOICES = {
 
 CONTRACTS = {
     "blanket1_DGS": {
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 0,
         "contract_agency": "DGS",
         "start_date": datetime(2020, 7, 1),
@@ -264,7 +264,7 @@ CONTRACTS = {
         "dollar_spent": 50.00,
     },
     "blanket1_DPW": {
-        "po_nbr": "111",
+        "po_nbr": "P111",
         "release_nbr": 0,
         "contract_agency": "DPW",
         "start_date": datetime(2020, 7, 1),
@@ -273,7 +273,7 @@ CONTRACTS = {
         "dollar_spent": 50.00,
     },
     "blanket4": {
-        "po_nbr": "444",
+        "po_nbr": "P444",
         "release_nbr": 0,
         "contract_agency": "AGY",
         "start_date": datetime(2021, 7, 1),
@@ -282,7 +282,7 @@ CONTRACTS = {
         "dollar_spent": 10.00,
     },
     "blanket7": {
-        "po_nbr": "777",
+        "po_nbr": "P777",
         "release_nbr": 0,
         "contract_agency": "DGS",
         "start_date": datetime(2010, 7, 1),


### PR DESCRIPTION
## Summary

Implements the `ContractManagement.update_po_list()` method

Fixes #84 

## Changes Proposed

- Updates CitiBuy test data to include the "P" in the PO Number field
- Implements `ContractManagement.update_po_list()` method

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the `ContractManagement.update_po_list()` method
1. All tests should pass
