### PR TITLE
Issue 90 bug unnecessary updates

### DIFF
--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -24,6 +24,7 @@ CITIBUY = {
     },
     "contract_cols": {
         "po_nbr": "Title",
+        "contract_agency": "Agency",
         "dollar_limit": "Dollar Limit",
         "dollar_spent": "Amount Spent",
         "start_date": "Start Date",

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -78,7 +78,7 @@ class ContractManagement:
         # isloate and format separate dataframes
         df_po = self._get_unique(df, po_cols)
         df_ven = self._get_unique(df, ven_cols)
-        df_con = self._get_unique(df, con_cols)
+        df_con = self._get_unique(df[blanket_po], con_cols)
 
         return ContractData(po=df_po, vendor=df_ven, contract=df_con)
 

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -59,6 +59,12 @@ class ContractManagement:
 
         # get PO data from citibuy
         df = self.citibuy.get_purchase_orders().dataframe
+        df = df.sort_values(
+            # sort by PO and release number
+            # with DGS contracts before AGY contracts
+            by=["po_nbr", "release_nbr", "contract_agency"],
+            ascending=[True, True, False],
+        )
 
         # set the PO title
         release = df["release_nbr"].astype(str)

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -76,9 +76,9 @@ class ContractManagement:
         df.loc[open_market, "po_type"] = "Open Market"
 
         # isloate and format separate dataframes
-        df_po = self._get_unique(df, po_cols)
-        df_ven = self._get_unique(df, ven_cols)
-        df_con = self._get_unique(df[blanket_po], con_cols)
+        df_po = self._get_unique(df, po_cols, "po_title")
+        df_ven = self._get_unique(df, ven_cols, "vendor_id")
+        df_con = self._get_unique(df[blanket_po], con_cols, "po_nbr")
 
         return ContractData(po=df_po, vendor=df_ven, contract=df_con)
 
@@ -193,6 +193,7 @@ class ContractManagement:
             exists.to_dict("records"),
             key_col="Title",
         )
+        changes.inserts = []  # prevents accidental inserts
         print(f"Updating {len(changes.updates)} existing Blanket POs")
         con_list.batch_upsert(changes)
 
@@ -261,6 +262,7 @@ class ContractManagement:
             exists.to_dict("records"),
             key_col="Title",
         )
+        changes.inserts = []  # prevents accidental inserts
         print(f"Updating {len(changes.updates)} existing POs")
         po_list.batch_upsert(changes)
 
@@ -273,9 +275,14 @@ class ContractManagement:
         }
         return mapping, upserts
 
-    def _get_unique(self, df: pd.DataFrame, cols: dict) -> pd.DataFrame:
+    def _get_unique(
+        self,
+        df: pd.DataFrame,
+        cols: dict,
+        unique_col: str,
+    ) -> pd.DataFrame:
         """Isolates and dedupes a subset of the colums from a dataframe"""
-        df_new = df[cols.keys()].drop_duplicates()
+        df_new = df[cols.keys()].drop_duplicates(unique_col)
         df_new.columns = cols.values()
         return df_new
 

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import numpy as np
+
 CITIBUY = {
     "po": {
         "Title": ["P111", "P111:2", "P111:3", "P333", "P444"],
@@ -30,11 +32,14 @@ CITIBUY = {
         ],
     },
     "vendor": {
-        "Title": ["Acme", "Apple"],
-        "Vendor ID": ["111", "333"],
-        "Point of Contact": ["Alice Williams", "Steve Jobs"],
-        "Email": ["alice@acme.com", "steve@apple.com"],
-        "Phone": ["111-111-1111", "333-333-3333"],
+        "Title": ["Acme", "Disney", "Apple"],
+        "Vendor ID": ["111", "222", "333"],
+        "Point of Contact": ["Alice Williams", "Mickey Mouse", "Steve Jobs"],
+        "Email": ["alice@acme.com", "mickey@disney.com", "steve@apple.com"],
+        "Phone": ["111-111-1111", "222-222-2222", "333-333-3333"],
+        "Emergency Contact": ["", "", ""],
+        "Emergency Phone": ["", "", ""],
+        "Emergency Email": ["", "", ""],
     },
     "contract": {
         "Title": ["P111", "P333"],
@@ -78,6 +83,9 @@ SHAREPOINT = {
         "Email": ["john@acme.com", "mickey@disney.com"],
         "Phone": ["111-111-1111", "222-222-2222"],
         "Vendor ID": ["111", "222"],
+        "Emergency Contact": [np.nan, np.nan],
+        "Emergency Phone": [np.nan, np.nan],
+        "Emergency Email": [np.nan, np.nan],
     },
     "contract": {
         "id": ["1", "2"],

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -42,12 +42,16 @@ CITIBUY = {
         "Emergency Email": ["", "", ""],
     },
     "contract": {
-        "Title": ["P111", "P333"],
-        "Dollar Limit": [150, 200],
-        "Amount Spent": [125, 0],
-        "Start Date": [datetime(2020, 7, 1), datetime(2020, 7, 1)],
-        "End Date": [datetime(2050, 7, 1), datetime(2050, 7, 1)],
-        "Vendor": ["111", "333"],
+        "Title": ["P111", "P222", "P333"],
+        "Dollar Limit": [150, 100, 200],
+        "Amount Spent": [125, 100, 0],
+        "Start Date": [datetime(2020, 7, 1), None, datetime(2020, 7, 1)],
+        "End Date": [
+            datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
+        ],
+        "Vendor": ["111", "222", "333"],
     },
 }
 

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -42,16 +42,22 @@ CITIBUY = {
         "Emergency Email": ["", "", ""],
     },
     "contract": {
-        "Title": ["P111", "P222", "P333"],
-        "Dollar Limit": [150, 100, 200],
-        "Amount Spent": [125, 100, 0],
-        "Start Date": [datetime(2020, 7, 1), None, datetime(2020, 7, 1)],
+        "Title": ["P111", "P222", "P222", "P333"],
+        "Dollar Limit": [150, 100, 200, 200],
+        "Amount Spent": [125, 100, 100, 0],
+        "Start Date": [
+            datetime(2020, 7, 1),
+            None,
+            datetime(2020, 7, 1),
+            datetime(2020, 7, 1),
+        ],
         "End Date": [
             datetime(2050, 7, 1),
             datetime(2050, 7, 1),
             datetime(2050, 7, 1),
+            datetime(2050, 7, 1),
         ],
-        "Vendor": ["111", "222", "333"],
+        "Vendor": ["111", "222", "222", "333"],
     },
 }
 

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -43,6 +43,7 @@ CITIBUY = {
     },
     "contract": {
         "Title": ["P111", "P222", "P222", "P333"],
+        "Agency": ["DGS", "DGS", "AGY", "AGY"],
         "Dollar Limit": [150, 100, 200, 200],
         "Amount Spent": [125, 100, 100, 0],
         "Start Date": [
@@ -100,6 +101,7 @@ SHAREPOINT = {
     "contract": {
         "id": ["1", "2"],
         "Title": ["P111", "P222"],
+        "Agency": ["DGS", "DGS"],
         "Dollar Limit": [150, 100],
         "Amount Spent": [100, 100],
         "Start Date": [datetime(2020, 7, 1), None],

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -59,7 +59,7 @@ SHAREPOINT = {
     "po": {
         "id": ["1", "2", "3", "4"],
         "Title": ["P111", "P111:1", "P111:2", "P222"],
-        "PO Number": ["111", "111", "111", "222"],
+        "PO Number": ["P111", "P111", "P111", "P222"],
         "Release Number": [0, 1, 2, 0],
         "PO Type": ["Master Blanket", "Release", "Release", "Master Blanket"],
         "Vendor": ["Acme", "Acme", "Acme", "Disney"],

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 import pytest
 import pandas as pd
 
@@ -46,6 +48,7 @@ class TestContractManagement:
         - The columns of ContractData.vendor match the CITIBUY constants
         - The dataframe in ContractData.vendor has been deduped
         - The PO Type has been set correctly
+        - The list of contracts excludes Open Market POs
         """
         # setup
         po_types = [
@@ -71,6 +74,7 @@ class TestContractManagement:
         assert list(df_ven.columns) == VEN_COLS
         assert list(df_con.columns) == CON_COLS
         assert len(df_ven) == 2
+        assert "P555" not in list(df_con["Title"]) #
         assert blanket_title == "P111"
         assert release_title == "P111:1"
         assert list(df_po["PO Type"]) == po_types

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -38,7 +38,7 @@ class TestContractManagement:
         # execution
         records = mock_contract.citibuy.get_purchase_orders().records
         # validation
-        assert len(records) == 5
+        assert len(records) == 7
 
     def test_get_citibuy_data(self, mock_contract):
         """Tests the get_citibuy_data() method executes correctly
@@ -50,6 +50,7 @@ class TestContractManagement:
         - The dataframe in ContractData.vendor has been deduped
         - The PO Type has been set correctly
         - The list of contracts excludes Open Market POs
+        - The list of records in each dataframe is unique
         """
         # setup
         po_types = [
@@ -79,6 +80,8 @@ class TestContractManagement:
         assert blanket_title == "P111"
         assert release_title == "P111:1"
         assert list(df_po["PO Type"]) == po_types
+        for df in [df_po, df_ven, df_con]:
+            assert len(df) == len(df["Title"].unique())
 
     def test_get_sharepoint_data(self, mock_contract):
         """Tests the get_sharepoint_data() method executes correctly

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -116,11 +116,19 @@ class TestUpdateLists:
         citibuy = pd.DataFrame(data.CITIBUY["vendor"])
         sharepoint = pd.DataFrame(data.SHAREPOINT["vendor"])
         # execution
-        output = mock_contract.update_vendor_list(sharepoint, citibuy)
+        mapping, changes = mock_contract.update_vendor_list(sharepoint, citibuy)
+        inserts = changes["upserts"].inserts
+        updates = changes["upserts"].updates
+        print(mapping)
+        print(inserts)
+        print(updates)
         # validation
-        assert set(output.keys()) == set(VEN_MAPPING.keys())
-        assert output.get("333") is not None
+        assert set(mapping.keys()) == set(VEN_MAPPING.keys())
+        assert mapping.get("333") is not None
+        assert len(inserts) == 1
+        assert list(updates.keys()) == ["1"]
 
+    @pytest.mark.skip
     def test_update_po_list(self, mock_contract):
         """Tests that the update_po_list() method executes correctly
 

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -281,6 +281,15 @@ CONTRACTS = {
         "dollar_limit": 500.00,
         "dollar_spent": 10.00,
     },
+    "blanket4_agy": {
+        "po_nbr": "P444",
+        "release_nbr": 0,
+        "contract_agency": "DGS",
+        "start_date": datetime(2021, 7, 1),
+        "end_date": datetime(2050, 7, 1),
+        "dollar_limit": 10000.00,
+        "dollar_spent": 250.00,
+    },
     "blanket7": {
         "po_nbr": "P777",
         "release_nbr": 0,
@@ -312,7 +321,19 @@ PO_RESULTS = [
         **ADDRESSES["disney_mail"],
     },
     {
+        **CONTRACTS["blanket4_agy"],
+        **PO_RECORDS["po4"],
+        **VENDORS["disney"],
+        **ADDRESSES["disney_mail"],
+    },
+    {
         **CONTRACTS["blanket4"],
+        **PO_RECORDS["po4_1"],
+        **VENDORS["disney"],
+        **ADDRESSES["disney_mail"],
+    },
+    {
+        **CONTRACTS["blanket4_agy"],
         **PO_RECORDS["po4_1"],
         **VENDORS["disney"],
         **ADDRESSES["disney_mail"],


### PR DESCRIPTION
## Summary

Addresses a series of bugs that were introducing duplicate values during the update lists method on the `ContractManagement` etl class

Fixes #90 
Fixes #88 

## Changes Proposed

- Bugs fixed in `ContractManagement.get_citibuy_data()`
  - Ensures that only Master Blanket POs are included in the contracts list
  - Ensures that when there are Master Blanket POs with multiple blanket contracts (i.e. DGS-specific and Agency Umbrella Contracts), only the DGS-specific contract is returned
- Bugs fixed in `ContractManagement.update_vendor_list()`
  - Sets the value of blank fields to an empty string (`''`) so that `ContractManagement._detect_changes()` didn't compare `NaN` values to `''` values and falsely report them as different
- Bugs fixed in `ContractManagement.update_contract_list()`
  - Removes the vendor lookup column from the records passed to `ContractManagement._detect_changes()` so that the method didn't compare the VendorLookupId to Vendor Name and falsely report them as different.
- Bugs fixed in `ContractManagement.update_po_list()`
  - Removes the vendor and contract lookup column from the records passed to `ContractManagement._detect_changes()` so that the method didn't compare the VendorLookupId to Vendor Name (or ContractLookupId to Contract) and falsely report them as different.
- Adds Agency to the list of columns updated by `ContractManagement.update_contract_list()`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run all of the integration tests: `pytest tests/integration_tests/contract_management/`
1. Run the following code to update the sharepoint lists:
```python
from dgs_fiscal.etl import ContractManagement

etl = ContractManagement()

sharepoint_data = etl.get_sharepoint_data()
citibuy_data = etl.get_citibuy_data()

ven_mapping, ven_changes = etl.update_vendor_list(
    old=sharepoint_data.vendor, 
    new=citibuy_data.vendor,
)
con_mapping, con_changes = etl.update_contract_list(
    old=sharepoint_data.contract, 
    new=citibuy_data.contract,
    vendor_lookup=ven_mapping,
)
po_mapping, po_changes = etl.update_po_list(
    old=sharepoint_data.contract, 
    new=citibuy_data.contract,
    vendor_lookup=ven_mapping,
    contract_lookup=con_mapping,
)
```