### PR TITLE
Issue 32 get invoices

### DIFF
--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -21,6 +21,25 @@ class CitiBuy:
     engine: sqlalchemy.Engine
     """
 
+    INVOICE_STATUS = {
+        "4II": "4II - In Progress",
+        "4IR": "4IR - Ready for Approval",
+        "4IA": "4IA - Approved for Payment",
+        "4IP": "4IP - Paid",
+        "4IC": "4IC - Cancelled",
+        "4IRT": "4IRT - Returned",
+    }
+    PO_STATUS = {
+        "3PRS": "3PRS - Ready to Send",
+        "3PS": "3PS - Sent",
+        "3PRT": "3PRT - Returned",
+        "3PRA": "3PRA - Ready for Approval",
+        "3PPR": "3PPR - Partial Receipt",
+        "3PI": "3PI - In Progress",
+        "3PCR": "3PCR - Completed Receipt",
+        "3PCO": "3PCO - Closed",
+    }
+
     def __init__(
         self,
         config: Dynaconf = settings,

--- a/app/src/dgs_fiscal/systems/citibuy/models/__init__.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/__init__.py
@@ -1,7 +1,10 @@
 __all__ = ["PurchaseOrder", "Vendor", "Invoice", "Base"]
 
 from dgs_fiscal.systems.citibuy.models.base import Base
-from dgs_fiscal.systems.citibuy.models.invoice_tables import Invoice
+from dgs_fiscal.systems.citibuy.models.invoice_tables import (
+    Invoice,
+    InvoiceStatusHistory,
+)
 from dgs_fiscal.systems.citibuy.models.po_tables import (
     PurchaseOrder,
     BlanketContract,

--- a/app/src/dgs_fiscal/systems/citibuy/models/base.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/base.py
@@ -4,7 +4,7 @@ from sqlalchemy import (
     Column,
     Integer,
     String,
-    Float,
+    Numeric,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,

--- a/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
@@ -14,7 +14,7 @@ class Invoice(db.Base):
     invoice_nbr = db.Column("INVOICE_NBR", db.String)
     invoice_date = db.Column("INVOICE_DATE", db.DateTime)
     status = db.Column("INVOICE_STATUS", db.String)
-    amount = db.Column("INVOICE_AMT", db.Float(asdecimal=True))
+    amount = db.Column("INVOICE_AMT", db.Numeric(precision=2))
     vendor_id = db.Column(
         "VENDOR_NBR",
         db.String,
@@ -22,8 +22,20 @@ class Invoice(db.Base):
     )
 
     # relationship
-    purchase_order = db.relationship("Vendor", backref="invoices")
+    purchase_order = db.relationship("PurchaseOrder", backref="invoices")
     status_history = db.relationship("InvoiceStatusHistory", backref="invoice")
+
+    # column list for querying
+    columns = (
+        "id",
+        "po_nbr",
+        "release_nbr",
+        "invoice_nbr",
+        "invoice_date",
+        "status",
+        "amount",
+        "vendor_id",
+    )
 
 
 class InvoiceStatusHistory(db.Base):

--- a/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
@@ -11,7 +11,7 @@ class Invoice(db.Base):
     id = db.Column("ID", db.String, primary_key=True)
     po_nbr = db.Column("PO_NBR", db.String)
     release_nbr = db.Column("RELEASE_NBR", db.Integer)
-    invoice_number = db.Column("INVOICE_NBR", db.String)
+    invoice_nbr = db.Column("INVOICE_NBR", db.String)
     invoice_date = db.Column("INVOICE_DATE", db.DateTime)
     status = db.Column("INVOICE_STATUS", db.String)
     amount = db.Column("INVOICE_AMT", db.Float(asdecimal=True))
@@ -23,3 +23,23 @@ class Invoice(db.Base):
 
     # relationship
     purchase_order = db.relationship("Vendor", backref="invoices")
+    status_history = db.relationship("InvoiceStatusHistory", backref="invoice")
+
+
+class InvoiceStatusHistory(db.Base):
+    """Table that records time stamps of each invoice's previous statuses"""
+
+    __tablename__ = "INVOICE_STATUS_DATES"
+
+    # column
+    id = db.Column("ID", db.String, primary_key=True)
+    invoice_nbr = db.Column("INVOIC_NBR", db.String)
+    vendor_id = db.Column("VENDOR_NBR", db.String)
+    from_status = db.Column("FROM_STATUS", db.String)
+    to_status = db.Column("TO_STATUS", db.String)
+    status_date = db.Column("INVOICE_STATUS_DATE", db.DateTime)
+    invoice_id = db.Column(
+        "HEADER_ID",
+        db.String,
+        db.ForeignKey("INVOICE_HDR.ID"),
+    )

--- a/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
@@ -12,7 +12,7 @@ class PurchaseOrder(db.Base):
     agency = db.Column("DEPT_NBR_PREFIX_REF", db.String)
     status = db.Column("CURRENT_HDR_STATUS", db.String)
     date = db.Column("PO_DATE", db.DateTime)
-    cost = db.Column("ACTUAL_COST", db.Float(precision=2))
+    cost = db.Column("ACTUAL_COST", db.Numeric(precision=2))
     desc = db.Column("SHORT_DESC", db.String)
     buyer = db.Column("PURCHASER", db.String)
     location = db.Column("LOC_ID", db.String)
@@ -49,8 +49,8 @@ class BlanketContract(db.Base):
     contract_agency = db.Column("DEPT_NBR_PRFX", db.String, primary_key=True)
     start_date = db.Column("BLANKET_BEG_DATE", db.DateTime)
     end_date = db.Column("BLANKET_END_DATE", db.DateTime)
-    dollar_limit = db.Column("BLANKET_DOLLAR_LIMIT", db.Float(precision=2))
-    dollar_spent = db.Column("BLANKET_DOLLAR_TODATE", db.Float(precision=2))
+    dollar_limit = db.Column("BLANKET_DOLLAR_LIMIT", db.Numeric(precision=2))
+    dollar_spent = db.Column("BLANKET_DOLLAR_TODATE", db.Numeric(precision=2))
 
     # column list for querying
     columns = (

--- a/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/vendor_tables.py
@@ -15,6 +15,7 @@ class Vendor(db.Base):
 
     # relationships
     purchase_orders = db.relationship("PurchaseOrder", backref="vendor")
+    invoices = db.relationship("Invoice", backref="vendor")
 
     # column list for querying
     columns = ("name", "emg_contact", "emg_email", "emg_phone")

--- a/app/tests/unit_tests/citibuy/data.py
+++ b/app/tests/unit_tests/citibuy/data.py
@@ -1,0 +1,50 @@
+from tests.utils import citibuy_data as mock_data
+
+PO_RESULTS = [
+    {
+        **mock_data.CONTRACTS["blanket1_DGS"],
+        **mock_data.PO_RECORDS["po1"],
+        **mock_data.VENDORS["acme"],
+        **mock_data.ADDRESSES["acme_mail"],
+    },
+    {
+        **mock_data.CONTRACTS["blanket1_DGS"],
+        **mock_data.PO_RECORDS["po1_1"],
+        **mock_data.VENDORS["acme"],
+        **mock_data.ADDRESSES["acme_mail"],
+    },
+    {
+        **mock_data.CONTRACTS["blanket4"],
+        **mock_data.PO_RECORDS["po4"],
+        **mock_data.VENDORS["disney"],
+        **mock_data.ADDRESSES["disney_mail"],
+    },
+    {
+        **mock_data.CONTRACTS["blanket4_agy"],
+        **mock_data.PO_RECORDS["po4"],
+        **mock_data.VENDORS["disney"],
+        **mock_data.ADDRESSES["disney_mail"],
+    },
+    {
+        **mock_data.CONTRACTS["blanket4"],
+        **mock_data.PO_RECORDS["po4_1"],
+        **mock_data.VENDORS["disney"],
+        **mock_data.ADDRESSES["disney_mail"],
+    },
+    {
+        **mock_data.CONTRACTS["blanket4_agy"],
+        **mock_data.PO_RECORDS["po4_1"],
+        **mock_data.VENDORS["disney"],
+        **mock_data.ADDRESSES["disney_mail"],
+    },
+    {
+        **mock_data.PO_RECORDS["po5"],
+        **mock_data.VENDORS["acme"],
+        **mock_data.ADDRESSES["acme_mail"],
+        "contract_agency": None,
+        "start_date": None,
+        "end_date": None,
+        "dollar_limit": None,
+        "dollar_spent": None,
+    },
+]

--- a/app/tests/unit_tests/citibuy/data.py
+++ b/app/tests/unit_tests/citibuy/data.py
@@ -48,3 +48,11 @@ PO_RESULTS = [
         "dollar_spent": None,
     },
 ]
+
+INVOICE_RESULTS = [
+    {**mock_data.INVOICES["inv2"], "name": "Acme"},
+    {**mock_data.INVOICES["inv3"], "name": "Acme"},
+    {**mock_data.INVOICES["inv5"], "name": "Disney"},
+    {**mock_data.INVOICES["inv6"], "name": "Disney"},
+    {**mock_data.INVOICES["inv8"], "name": "Disney"},
+]

--- a/app/tests/unit_tests/citibuy/test_client.py
+++ b/app/tests/unit_tests/citibuy/test_client.py
@@ -3,7 +3,7 @@ from pprint import pprint
 import pytest
 import sqlalchemy
 
-from tests.utils import citibuy_data as data
+from tests.unit_tests.citibuy import data
 from dgs_fiscal.systems import CitiBuy
 
 

--- a/app/tests/unit_tests/citibuy/test_client.py
+++ b/app/tests/unit_tests/citibuy/test_client.py
@@ -66,3 +66,32 @@ class TestGetPurchaseOrders:
         pprint(expected)
         # validation
         assert output == expected
+
+
+class TestGetInvoices:
+    """Tests the CitiBuy.get_invoices() method"""
+
+    def test_query_default(self, mock_citibuy):
+        """Tests that PurchaseOrders.get_records() returns all records when no
+        values are passed to the filter or limit paramaters
+
+        Validates the following conditions:
+        - All matching invoices are returned with the correct fields
+        - The results are returned as a list of dictionary items
+        - The results exclude invoices that were cancelled or paid more than
+          45 days ago
+        - The results exclude invoices on POs from other agencies
+        """
+        # setup
+        expected = data.INVOICE_RESULTS
+        # execution
+        output = mock_citibuy.get_invoices().records
+        print("OUTPUT")
+        pprint(output)
+        print("EXPECTED")
+        pprint(expected)
+        # validation
+        assert isinstance(output, list)
+        assert isinstance(output[0], dict)
+        assert len(output) == len(expected)
+        assert output == expected

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -19,19 +19,19 @@ VENDORS = {
 
 VEN_ADDRESS = {
     "acme_mail": {
-        "vendor_id": "111",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "address_id": "111",
         "address_type": "M",
         "default": "Y",
     },
     "acme_extra": {
-        "vendor_id": "111",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "address_id": "222",
         "address_type": "R",
         "default": "Y",
     },
     "disney": {
-        "vendor_id": "222",
+        "vendor_id": VENDORS["disney"]["vendor_id"],
         "address_id": "333",
         "address_type": "M",
         "default": "Y",
@@ -64,7 +64,7 @@ PO_RECORDS = {
     "po1": {
         "po_nbr": "P111",
         "release_nbr": 0,
-        "vendor_id": "111",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "status": "3PS",
         "agency": "DGS",
         "cost": 0.00,
@@ -77,7 +77,7 @@ PO_RECORDS = {
     "po1_1": {
         "po_nbr": "P111",
         "release_nbr": 1,
-        "vendor_id": "111",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "status": "3PPR",
         "agency": "DGS",
         "cost": 75.00,
@@ -91,7 +91,7 @@ PO_RECORDS = {
     "po1_2": {
         "po_nbr": "P111",
         "release_nbr": 2,
-        "vendor_id": "222",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "status": "3PPR",
         "agency": "DPW",
         "cost": 20.00,
@@ -105,7 +105,7 @@ PO_RECORDS = {
     "po2": {
         "po_nbr": "P222",
         "release_nbr": 0,
-        "vendor_id": "222",
+        "vendor_id": VENDORS["disney"]["vendor_id"],
         "status": "3PCO",
         "agency": "DGS",
         "cost": 15.50,
@@ -120,7 +120,7 @@ PO_RECORDS = {
     "po4": {
         "po_nbr": "P444",
         "release_nbr": 0,
-        "vendor_id": "222",
+        "vendor_id": VENDORS["disney"]["vendor_id"],
         "status": "3PS",
         "agency": "DPW",
         "cost": 0.00,
@@ -133,7 +133,7 @@ PO_RECORDS = {
     "po4_1": {
         "po_nbr": "P444",
         "release_nbr": 1,
-        "vendor_id": "222",
+        "vendor_id": VENDORS["disney"]["vendor_id"],
         "status": "3PPR",
         "agency": "DGS",
         "cost": 10.00,
@@ -142,11 +142,11 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
-    # Open Market PO between DGS and Disney, status: Sent
+    # Open Market PO between DGS and Acme, status: Sent
     "po5": {
         "po_nbr": "P555",
         "release_nbr": 0,
-        "vendor_id": "111",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "status": "3PS",
         "agency": "DGS",
         "cost": 20.00,
@@ -155,12 +155,12 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
-    # Open Market PO between Disney and DPW, status: Sent
+    # Open Market PO between Acme and DPW, status: Sent
     # This PO is excluded because it isn't available to DGS
     "po6": {
         "po_nbr": "P666",
         "release_nbr": 0,
-        "vendor_id": "111",
+        "vendor_id": VENDORS["acme"]["vendor_id"],
         "status": "3PS",
         "agency": "DPW",
         "cost": 20.00,
@@ -174,7 +174,7 @@ PO_RECORDS = {
     "po7": {
         "po_nbr": "P777",
         "release_nbr": 0,
-        "vendor_id": "222",
+        "vendor_id": VENDORS["disney"]["vendor_id"],
         "status": "3PCO",
         "agency": "DGS",
         "cost": 0.00,
@@ -185,14 +185,63 @@ PO_RECORDS = {
     },
 }
 
+CONTRACTS = {
+    "blanket1_DGS": {
+        "po_nbr": PO_RECORDS["po1"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po1"]["release_nbr"],
+        "contract_agency": "DGS",
+        "start_date": datetime(2020, 7, 1),
+        "end_date": datetime(2050, 7, 1),
+        "dollar_limit": 750.00,
+        "dollar_spent": 50.00,
+    },
+    "blanket1_DPW": {
+        "po_nbr": PO_RECORDS["po1"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po1"]["release_nbr"],
+        "contract_agency": "DPW",
+        "start_date": datetime(2020, 7, 1),
+        "end_date": datetime(2050, 7, 1),
+        "dollar_limit": 250.00,
+        "dollar_spent": 50.00,
+    },
+    "blanket4": {
+        "po_nbr": PO_RECORDS["po4"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po4"]["release_nbr"],
+        "contract_agency": "AGY",
+        "start_date": datetime(2021, 7, 1),
+        "end_date": datetime(2050, 7, 1),
+        "dollar_limit": 500.00,
+        "dollar_spent": 10.00,
+    },
+    "blanket4_agy": {
+        "po_nbr": PO_RECORDS["po4"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po4"]["release_nbr"],
+        "contract_agency": "DGS",
+        "start_date": datetime(2021, 7, 1),
+        "end_date": datetime(2050, 7, 1),
+        "dollar_limit": 10000.00,
+        "dollar_spent": 250.00,
+    },
+    "blanket7": {
+        "po_nbr": PO_RECORDS["po7"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po7"]["release_nbr"],
+        "contract_agency": "DGS",
+        "start_date": datetime(2010, 7, 1),
+        "end_date": datetime(2020, 7, 1),
+        "dollar_limit": 500.00,
+        "dollar_spent": 20.00,
+    },
+}
+
+
 INVOICES = {
     # Acme invoice for DGS, status: Paid
     "inv1": {
         "id": "invoice1",
-        "po_nbr": "P111",
-        "release_nbr": 1,
-        "vendor_id": "111",
-        "invoice_number": "Invoice#1",
+        "po_nbr": PO_RECORDS["po1_1"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po1_1"]["release_nbr"],
+        "vendor_id": VENDORS["acme"]["vendor_id"],
+        "invoice_nbr": "Invoice#1",
         "status": "4IP",
         "amount": 10.25,
         "invoice_date": datetime(2020, 8, 30),
@@ -200,21 +249,21 @@ INVOICES = {
     # Acme invoice for DGS, status: Paid
     "inv2": {
         "id": "invoice2",
-        "po_nbr": "P111",
-        "release_nbr": 1,
-        "vendor_id": "111",
-        "invoice_number": "Invoice#2",
+        "po_nbr": PO_RECORDS["po1_1"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po1_1"]["release_nbr"],
+        "vendor_id": VENDORS["acme"]["vendor_id"],
+        "invoice_nbr": "Invoice#2",
         "status": "4IP",
         "amount": 25.00,
         "invoice_date": datetime(2020, 7, 1),
     },
-    # Acme invoice for DGS, status: In
+    # Acme invoice for DGS, status: Approved for Payment
     "inv3": {
         "id": "invoice3",
-        "po_nbr": "P111",
-        "release_nbr": 1,
-        "vendor_id": "111",
-        "invoice_number": "Invoice#2",
+        "po_nbr": PO_RECORDS["po1_1"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po1_1"]["release_nbr"],
+        "vendor_id": VENDORS["acme"]["vendor_id"],
+        "invoice_nbr": "Invoice#2",
         "status": "4IA",
         "amount": 25.00,
         "invoice_date": datetime(2020, 7, 1),
@@ -223,10 +272,10 @@ INVOICES = {
     # Excluded because it's for DPW
     "inv4": {
         "id": "invoice4",
-        "po_nbr": "P111",
-        "release_nbr": 2,
-        "vendor_id": "111",
-        "invoice_number": "Invoice#3",
+        "po_nbr": PO_RECORDS["po1_2"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po1_2"]["release_nbr"],
+        "vendor_id": VENDORS["acme"]["vendor_id"],
+        "invoice_nbr": "Invoice#3",
         "status": "4II",
         "amount": 10.50,
         "invoice_date": datetime(2020, 8, 15),
@@ -234,10 +283,10 @@ INVOICES = {
     # Disney invoice for DGS, status: Approved for Payment
     "disney_inv5": {
         "id": "invoice5",
-        "po_nbr": "P222",
-        "release_nbr": 0,
-        "vendor_id": "222",
-        "invoice_number": "#1",
+        "po_nbr": PO_RECORDS["po2"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po2"]["release_nbr"],
+        "vendor_id": VENDORS["disney"]["vendor_id"],
+        "invoice_nbr": "#1",
         "status": "4IA",
         "amount": 10.50,
         "invoice_date": datetime(2020, 9, 30),
@@ -245,82 +294,100 @@ INVOICES = {
     # Disney invoice for DGS, status: Cancelled
     "disney_inv6": {
         "id": "invoice6",
-        "po_nbr": "P222",
-        "release_nbr": 0,
-        "vendor_id": "222",
-        "invoice_number": "#2",
+        "po_nbr": PO_RECORDS["po2"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po2"]["release_nbr"],
+        "vendor_id": VENDORS["disney"]["vendor_id"],
+        "invoice_nbr": "#2",
         "status": "4IC",
         "amount": 5.00,
         "invoice_date": datetime(2020, 7, 1),
     },
-    # Disney invoice for DGS, status: In Progress
+    # Disney invoice for DGS, status: Cancelled
     "disney_inv7": {
         "id": "invoice7",
         "po_nbr": "P333",
         "release_nbr": 0,
-        "vendor_id": "222",
-        "invoice_number": "#3",
-        "status": "4II",
+        "vendor_id": VENDORS["disney"]["vendor_id"],
+        "invoice_nbr": "#3",
+        "status": "4IC",
         "amount": 5.00,
         "invoice_date": datetime(2020, 7, 15),
     },
     # Disney invoice for DGS, status: In Progress
     "disney_inv8": {
         "id": "invoice8",
-        "po_nbr": "P444",
-        "release_nbr": 1,
-        "vendor_id": "222",
-        "invoice_number": "#4",
-        "status": "4IP",
+        "po_nbr": PO_RECORDS["po4_1"]["po_nbr"],
+        "release_nbr": PO_RECORDS["po4_1"]["release_nbr"],
+        "vendor_id": VENDORS["disney"]["vendor_id"],
+        "invoice_nbr": "#4",
+        "status": "4II",
         "amount": 10.00,
         "invoice_date": datetime(2020, 8, 1),
     },
 }
 
-CONTRACTS = {
-    "blanket1_DGS": {
-        "po_nbr": "P111",
-        "release_nbr": 0,
-        "contract_agency": "DGS",
-        "start_date": datetime(2020, 7, 1),
-        "end_date": datetime(2050, 7, 1),
-        "dollar_limit": 750.00,
-        "dollar_spent": 50.00,
+INVOICE_HISTORY = {
+    "inv1_4IR": {
+        "id": "update_1.1",
+        "invoice_id": INVOICES["inv1"]["id"],
+        "invoice_nbr": INVOICES["inv1"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv1"]["vendor_id"],
+        "from_status": "4II",
+        "to_status": "4IR",
+        "status_date": datetime(2020, 8, 1),
     },
-    "blanket1_DPW": {
-        "po_nbr": "P111",
-        "release_nbr": 0,
-        "contract_agency": "DPW",
-        "start_date": datetime(2020, 7, 1),
-        "end_date": datetime(2050, 7, 1),
-        "dollar_limit": 250.00,
-        "dollar_spent": 50.00,
+    "inv1_4IA": {
+        "id": "update_1.2",
+        "invoice_id": INVOICES["inv1"]["id"],
+        "invoice_nbr": INVOICES["inv1"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv1"]["vendor_id"],
+        "from_status": "4IR",
+        "to_status": "4IA",
+        "status_date": datetime(2020, 9, 1),
     },
-    "blanket4": {
-        "po_nbr": "P444",
-        "release_nbr": 0,
-        "contract_agency": "AGY",
-        "start_date": datetime(2021, 7, 1),
-        "end_date": datetime(2050, 7, 1),
-        "dollar_limit": 500.00,
-        "dollar_spent": 10.00,
+    "inv1_4IP": {
+        "id": "update_1.3",
+        "invoice_id": INVOICES["inv1"]["id"],
+        "invoice_nbr": INVOICES["inv1"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv1"]["vendor_id"],
+        "from_status": "4IA",
+        "to_status": "4IP",
+        "status_date": datetime(2025, 10, 1),
     },
-    "blanket4_agy": {
-        "po_nbr": "P444",
-        "release_nbr": 0,
-        "contract_agency": "DGS",
-        "start_date": datetime(2021, 7, 1),
-        "end_date": datetime(2050, 7, 1),
-        "dollar_limit": 10000.00,
-        "dollar_spent": 250.00,
+    "inv2_4IP": {
+        "id": "update_2",
+        "invoice_id": INVOICES["inv2"]["id"],
+        "invoice_nbr": INVOICES["inv2"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv2"]["vendor_id"],
+        "from_status": "4IA",
+        "to_status": "4IP",
+        "status_date": datetime(2025, 9, 1),
     },
-    "blanket7": {
-        "po_nbr": "P777",
-        "release_nbr": 0,
-        "contract_agency": "DGS",
-        "start_date": datetime(2010, 7, 1),
-        "end_date": datetime(2020, 7, 1),
-        "dollar_limit": 500.00,
-        "dollar_spent": 20.00,
+    "inv3_4IA": {
+        "id": "update_3",
+        "invoice_id": INVOICES["inv3"]["id"],
+        "invoice_nbr": INVOICES["inv3"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv3"]["vendor_id"],
+        "from_status": "4IR",
+        "to_status": "4IA",
+        "status_date": datetime(2025, 9, 1),
+    },
+    "inv6_4IC": {
+        "id": "update_6",
+        "invoice_id": INVOICES["disney_inv6"]["id"],
+        "invoice_nbr": INVOICES["disney_inv6"]["invoice_nbr"],
+        "vendor_id": INVOICES["disney_inv6"]["vendor_id"],
+        "from_status": "4IC",
+        "to_status": "4IC",
+        "status_date": datetime(2025, 9, 1),
+    },
+    "inv7_4IC": {
+        "id": "update_7",
+        "invoice_id": INVOICES["disney_inv7"]["id"],
+        "invoice_nbr": INVOICES["disney_inv7"]["invoice_nbr"],
+        "vendor_id": INVOICES["disney_inv7"]["vendor_id"],
+        "from_status": "4IC",
+        "to_status": "4IC",
+        "status_date": datetime(2020, 9, 1),
     },
 }

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -60,6 +60,7 @@ ADDRESSES = {
 }
 
 PO_RECORDS = {
+    # Blanket PO between Acme and DGS, status: Sent
     "po1": {
         "po_nbr": "P111",
         "release_nbr": 0,
@@ -72,6 +73,7 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # PO Release between Acme and DGS, status: Partial Receipt
     "po1_1": {
         "po_nbr": "P111",
         "release_nbr": 1,
@@ -84,6 +86,8 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # PO Release between Acme and DPW, status: Partial Receipt
+    # Excluded because it's a DPW release
     "po1_2": {
         "po_nbr": "P111",
         "release_nbr": 2,
@@ -96,6 +100,8 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # Open Market PO between Disney and DGS, status: Closed
+    # Excluded because it's closed
     "po2": {
         "po_nbr": "P222",
         "release_nbr": 0,
@@ -108,6 +114,9 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # Blanket PO between Disney and DPW, status: Sent
+    # This is the PO for an Agency umbrella contract
+    # which allows DGS to create releases off of it
     "po4": {
         "po_nbr": "P444",
         "release_nbr": 0,
@@ -120,6 +129,7 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # PO Release between Disney and DGS, status: Partial Receipt
     "po4_1": {
         "po_nbr": "P444",
         "release_nbr": 1,
@@ -132,6 +142,7 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # Open Market PO between DGS and Disney, status: Sent
     "po5": {
         "po_nbr": "P555",
         "release_nbr": 0,
@@ -144,6 +155,8 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # Open Market PO between Disney and DPW, status: Sent
+    # This PO is excluded because it isn't available to DGS
     "po6": {
         "po_nbr": "P666",
         "release_nbr": 0,
@@ -156,6 +169,8 @@ PO_RECORDS = {
         "desc": "description",
         "location": "DGS",
     },
+    # Blanket PO between Disney and DGS, status: Closed
+    # This PO is excluded because it's closed
     "po7": {
         "po_nbr": "P777",
         "release_nbr": 0,
@@ -171,6 +186,7 @@ PO_RECORDS = {
 }
 
 INVOICES = {
+    # Acme invoice for DGS, status: Paid
     "inv1": {
         "id": "invoice1",
         "po_nbr": "P111",
@@ -179,8 +195,9 @@ INVOICES = {
         "invoice_number": "Invoice#1",
         "status": "4IP",
         "amount": 10.25,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 8, 30),
     },
+    # Acme invoice for DGS, status: Paid
     "inv2": {
         "id": "invoice2",
         "po_nbr": "P111",
@@ -189,8 +206,9 @@ INVOICES = {
         "invoice_number": "Invoice#2",
         "status": "4IP",
         "amount": 25.00,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 7, 1),
     },
+    # Acme invoice for DGS, status: In
     "inv3": {
         "id": "invoice3",
         "po_nbr": "P111",
@@ -199,48 +217,54 @@ INVOICES = {
         "invoice_number": "Invoice#2",
         "status": "4IA",
         "amount": 25.00,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 7, 1),
     },
+    # Acme invoice for DPW, status: In Progress
+    # Excluded because it's for DPW
     "inv4": {
         "id": "invoice4",
         "po_nbr": "P111",
-        "release_nbr": 1,
+        "release_nbr": 2,
         "vendor_id": "111",
         "invoice_number": "Invoice#3",
         "status": "4II",
         "amount": 10.50,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 8, 15),
     },
+    # Disney invoice for DGS, status: Approved for Payment
     "disney_inv5": {
         "id": "invoice5",
         "po_nbr": "P222",
         "release_nbr": 0,
         "vendor_id": "222",
         "invoice_number": "#1",
-        "status": "4IP",
+        "status": "4IA",
         "amount": 10.50,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 9, 30),
     },
+    # Disney invoice for DGS, status: Cancelled
     "disney_inv6": {
         "id": "invoice6",
         "po_nbr": "P222",
         "release_nbr": 0,
         "vendor_id": "222",
         "invoice_number": "#2",
-        "status": "4IP",
+        "status": "4IC",
         "amount": 5.00,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 7, 1),
     },
+    # Disney invoice for DGS, status: In Progress
     "disney_inv7": {
         "id": "invoice7",
         "po_nbr": "P333",
         "release_nbr": 0,
         "vendor_id": "222",
         "invoice_number": "#3",
-        "status": "4IP",
+        "status": "4II",
         "amount": 5.00,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 7, 15),
     },
+    # Disney invoice for DGS, status: In Progress
     "disney_inv8": {
         "id": "invoice8",
         "po_nbr": "P444",
@@ -249,7 +273,7 @@ INVOICES = {
         "invoice_number": "#4",
         "status": "4IP",
         "amount": 10.00,
-        "invoice_date": None,
+        "invoice_date": datetime(2020, 8, 1),
     },
 }
 
@@ -300,52 +324,3 @@ CONTRACTS = {
         "dollar_spent": 20.00,
     },
 }
-
-PO_RESULTS = [
-    {
-        **CONTRACTS["blanket1_DGS"],
-        **PO_RECORDS["po1"],
-        **VENDORS["acme"],
-        **ADDRESSES["acme_mail"],
-    },
-    {
-        **CONTRACTS["blanket1_DGS"],
-        **PO_RECORDS["po1_1"],
-        **VENDORS["acme"],
-        **ADDRESSES["acme_mail"],
-    },
-    {
-        **CONTRACTS["blanket4"],
-        **PO_RECORDS["po4"],
-        **VENDORS["disney"],
-        **ADDRESSES["disney_mail"],
-    },
-    {
-        **CONTRACTS["blanket4_agy"],
-        **PO_RECORDS["po4"],
-        **VENDORS["disney"],
-        **ADDRESSES["disney_mail"],
-    },
-    {
-        **CONTRACTS["blanket4"],
-        **PO_RECORDS["po4_1"],
-        **VENDORS["disney"],
-        **ADDRESSES["disney_mail"],
-    },
-    {
-        **CONTRACTS["blanket4_agy"],
-        **PO_RECORDS["po4_1"],
-        **VENDORS["disney"],
-        **ADDRESSES["disney_mail"],
-    },
-    {
-        **PO_RECORDS["po5"],
-        **VENDORS["acme"],
-        **ADDRESSES["acme_mail"],
-        "contract_agency": None,
-        "start_date": None,
-        "end_date": None,
-        "dollar_limit": None,
-        "dollar_spent": None,
-    },
-]

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -236,6 +236,7 @@ CONTRACTS = {
 
 INVOICES = {
     # Acme invoice for DGS, status: Paid
+    # Excluded because it was paid more than 45 days ago
     "inv1": {
         "id": "invoice1",
         "po_nbr": PO_RECORDS["po1_1"]["po_nbr"],
@@ -247,6 +248,7 @@ INVOICES = {
         "invoice_date": datetime(2020, 8, 30),
     },
     # Acme invoice for DGS, status: Paid
+    # Included because it was paid less than 45 days ago
     "inv2": {
         "id": "invoice2",
         "po_nbr": PO_RECORDS["po1_1"]["po_nbr"],
@@ -258,6 +260,7 @@ INVOICES = {
         "invoice_date": datetime(2020, 7, 1),
     },
     # Acme invoice for DGS, status: Approved for Payment
+    # Included because it hasn't yet been paid
     "inv3": {
         "id": "invoice3",
         "po_nbr": PO_RECORDS["po1_1"]["po_nbr"],
@@ -281,7 +284,8 @@ INVOICES = {
         "invoice_date": datetime(2020, 8, 15),
     },
     # Disney invoice for DGS, status: Approved for Payment
-    "disney_inv5": {
+    # Included because it hasn't yet been paid
+    "inv5": {
         "id": "invoice5",
         "po_nbr": PO_RECORDS["po2"]["po_nbr"],
         "release_nbr": PO_RECORDS["po2"]["release_nbr"],
@@ -292,7 +296,8 @@ INVOICES = {
         "invoice_date": datetime(2020, 9, 30),
     },
     # Disney invoice for DGS, status: Cancelled
-    "disney_inv6": {
+    # Included because it was canceled less than 45 days ago
+    "inv6": {
         "id": "invoice6",
         "po_nbr": PO_RECORDS["po2"]["po_nbr"],
         "release_nbr": PO_RECORDS["po2"]["release_nbr"],
@@ -303,7 +308,8 @@ INVOICES = {
         "invoice_date": datetime(2020, 7, 1),
     },
     # Disney invoice for DGS, status: Cancelled
-    "disney_inv7": {
+    # Excluded because it was cancelled more than 45 days ago
+    "inv7": {
         "id": "invoice7",
         "po_nbr": "P333",
         "release_nbr": 0,
@@ -314,7 +320,8 @@ INVOICES = {
         "invoice_date": datetime(2020, 7, 15),
     },
     # Disney invoice for DGS, status: In Progress
-    "disney_inv8": {
+    # Included because it hasn't yet been paid
+    "inv8": {
         "id": "invoice8",
         "po_nbr": PO_RECORDS["po4_1"]["po_nbr"],
         "release_nbr": PO_RECORDS["po4_1"]["release_nbr"],
@@ -352,7 +359,7 @@ INVOICE_HISTORY = {
         "vendor_id": INVOICES["inv1"]["vendor_id"],
         "from_status": "4IA",
         "to_status": "4IP",
-        "status_date": datetime(2025, 10, 1),
+        "status_date": datetime(2020, 10, 1),  # more than 45 days ago
     },
     "inv2_4IP": {
         "id": "update_2",
@@ -361,7 +368,7 @@ INVOICE_HISTORY = {
         "vendor_id": INVOICES["inv2"]["vendor_id"],
         "from_status": "4IA",
         "to_status": "4IP",
-        "status_date": datetime(2025, 9, 1),
+        "status_date": datetime(2025, 9, 1),  # less than 45 days ago
     },
     "inv3_4IA": {
         "id": "update_3",
@@ -374,20 +381,20 @@ INVOICE_HISTORY = {
     },
     "inv6_4IC": {
         "id": "update_6",
-        "invoice_id": INVOICES["disney_inv6"]["id"],
-        "invoice_nbr": INVOICES["disney_inv6"]["invoice_nbr"],
-        "vendor_id": INVOICES["disney_inv6"]["vendor_id"],
+        "invoice_id": INVOICES["inv6"]["id"],
+        "invoice_nbr": INVOICES["inv6"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv6"]["vendor_id"],
         "from_status": "4IC",
         "to_status": "4IC",
-        "status_date": datetime(2025, 9, 1),
+        "status_date": datetime(2025, 9, 1),  # less than 45 days ago
     },
     "inv7_4IC": {
         "id": "update_7",
-        "invoice_id": INVOICES["disney_inv7"]["id"],
-        "invoice_nbr": INVOICES["disney_inv7"]["invoice_nbr"],
-        "vendor_id": INVOICES["disney_inv7"]["vendor_id"],
+        "invoice_id": INVOICES["inv7"]["id"],
+        "invoice_nbr": INVOICES["inv7"]["invoice_nbr"],
+        "vendor_id": INVOICES["inv7"]["vendor_id"],
         "from_status": "4IC",
         "to_status": "4IC",
-        "status_date": datetime(2020, 9, 1),
+        "status_date": datetime(2020, 9, 1),  # more than 45 days ago
     },
 }

--- a/app/tests/utils/populate_citibuy_db.py
+++ b/app/tests/utils/populate_citibuy_db.py
@@ -37,10 +37,15 @@ def populate_db(session: Session) -> None:
     vendor_addresses = [
         models.VendorAddress(**va) for va in data.VEN_ADDRESS.values()
     ]
+    invoice_history = [
+        models.InvoiceStatusHistory(**status)
+        for status in data.INVOICE_HISTORY.values()
+    ]
     add_to_session(session, vendors)
     add_to_session(session, pos)
     add_to_session(session, invoices)
     add_to_session(session, contracts)
     add_to_session(session, addresses)
     add_to_session(session, vendor_addresses)
+    add_to_session(session, invoice_history)
     session.commit()


### PR DESCRIPTION
## Summary

Implements `CitiBuy.get_invoices()` method which retrieves a list of invoices from CitiBuy database

Fixes #32 

## Changes Proposed

- Adds a dictionary of PO and Invoice Statuses to `CitiBuy` ETL class
- Creates an `InvoiceStatusHistory` model class in `dgs_fiscal.citibuy.models` which represents the `INVOICE_STATUS_DATES` table in CitiBuy
- Implements the `CitiBuy.get_invoices()` class

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the unit tests: `pytest`
1. All tests should pass
