### PR TITLE
fix: Decimal serialization error

### DIFF
--- a/app/src/dgs_fiscal/systems/citibuy/models/base.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/base.py
@@ -4,7 +4,7 @@ from sqlalchemy import (
     Column,
     Integer,
     String,
-    Numeric,
+    Float,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,

--- a/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
@@ -14,7 +14,7 @@ class Invoice(db.Base):
     invoice_nbr = db.Column("INVOICE_NBR", db.String)
     invoice_date = db.Column("INVOICE_DATE", db.DateTime)
     status = db.Column("INVOICE_STATUS", db.String)
-    amount = db.Column("INVOICE_AMT", db.Numeric(precision=2))
+    amount = db.Column("INVOICE_AMT", db.Float(precision=2))
     vendor_id = db.Column(
         "VENDOR_NBR",
         db.String,

--- a/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
@@ -12,7 +12,7 @@ class PurchaseOrder(db.Base):
     agency = db.Column("DEPT_NBR_PREFIX_REF", db.String)
     status = db.Column("CURRENT_HDR_STATUS", db.String)
     date = db.Column("PO_DATE", db.DateTime)
-    cost = db.Column("ACTUAL_COST", db.Numeric(precision=2))
+    cost = db.Column("ACTUAL_COST", db.Float(precision=2))
     desc = db.Column("SHORT_DESC", db.String)
     buyer = db.Column("PURCHASER", db.String)
     location = db.Column("LOC_ID", db.String)
@@ -49,8 +49,8 @@ class BlanketContract(db.Base):
     contract_agency = db.Column("DEPT_NBR_PRFX", db.String, primary_key=True)
     start_date = db.Column("BLANKET_BEG_DATE", db.DateTime)
     end_date = db.Column("BLANKET_END_DATE", db.DateTime)
-    dollar_limit = db.Column("BLANKET_DOLLAR_LIMIT", db.Numeric(precision=2))
-    dollar_spent = db.Column("BLANKET_DOLLAR_TODATE", db.Numeric(precision=2))
+    dollar_limit = db.Column("BLANKET_DOLLAR_LIMIT", db.Float(precision=2))
+    dollar_spent = db.Column("BLANKET_DOLLAR_TODATE", db.Float(precision=2))
 
     # column list for querying
     columns = (


### PR DESCRIPTION
## Summary

The change from Float to Numeric in CitiBuy model tables caused a 
serialization error to be thrown by `ContractManagement.update_contract_list()` This commit fixes that issue 
by reverting them back to Float.

Fixes #101 

## Changes Proposed

- Reverts `Numeric` columns in `citibuy.models` sub-package to `Float`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. {Step 2}
1. {Step 3}
