### PR TITLE
Issue 104 wrong invoices returned

### DIFF
--- a/app/src/dgs_fiscal/etl/aging_report/constants.py
+++ b/app/src/dgs_fiscal/etl/aging_report/constants.py
@@ -9,5 +9,6 @@ CITIBUY = {
         "invoice_date": "Invoice Date",
         "amount": "Amount",
         "status": "Status",
+        "modified": "Last Modified",
     }
 }

--- a/app/src/dgs_fiscal/etl/aging_report/main.py
+++ b/app/src/dgs_fiscal/etl/aging_report/main.py
@@ -22,7 +22,7 @@ class AgingReport:
         SharePoint resources
     """
 
-    def __init__(self, citibuy_url: str) -> None:
+    def __init__(self, citibuy_url: str = None) -> None:
         """Inits the AgingReport class"""
         self.citibuy = CitiBuy(conn_url=citibuy_url)
         self.sharepoint = SharePoint()

--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -160,23 +160,24 @@ class CitiBuy:
         po = aliased(models.PurchaseOrder, name="po")
         ven = aliased(models.Vendor, name="vendor")
         inv = aliased(models.Invoice, name="invoice")
-        status = aliased(models.InvoiceStatusHistory, name="status")
+        # status = aliased(models.InvoiceStatusHistory, name="status")
 
         # create the foreign keys
-        fkey_status = inv.id == status.invoice_id
+        # fkey_status = inv.id == status.invoice_id
         fkey_vendor = inv.vendor_id == ven.vendor_id
         fkey_po = (po.po_nbr == inv.po_nbr) & (
             po.release_nbr == inv.release_nbr
         )
 
+        # TODO: remove this section
         # create a sub-query for recently closed and cancelled invoices
-        updated_recently = status.status_date > (date.today() - timedelta(45))
-        closed = sa.select(inv.id)
-        closed = closed.join(status, fkey_status)
-        closed = closed.where(inv.status == status.to_status)
-        closed = closed.where(updated_recently)
-        closed = closed.cte("recently_closed")  # creates a WITH clause
-        closed = sa.select(closed.c.id)  # isloates invoice ids from clause
+        # updated_recently = status.status_date > (date.today() - timedelta(45))
+        # closed = sa.select(inv.id)
+        # closed = closed.join(status, fkey_status)
+        # closed = closed.where(inv.status == status.to_status)
+        # closed = closed.where(updated_recently)
+        # closed = closed.cte("recently_closed")  # creates a WITH clause
+        # closed = sa.select(closed.c.id)  # isloates invoice ids from clause
 
         # create the return query
         query = sa.select(
@@ -190,7 +191,7 @@ class CitiBuy:
         query = query.where(
             # invoice still open or recently closed or cancelled
             (inv.status.not_in(("4IP", "4IC")))
-            | (inv.id.in_(closed))
+            | (inv.modified > (date.today() - timedelta(45)))
         )
         with Session(self.engine) as session:
             rows = session.execute(query).fetchall()

--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -160,26 +160,14 @@ class CitiBuy:
         po = aliased(models.PurchaseOrder, name="po")
         ven = aliased(models.Vendor, name="vendor")
         inv = aliased(models.Invoice, name="invoice")
-        # status = aliased(models.InvoiceStatusHistory, name="status")
 
-        # create the foreign keys
-        # fkey_status = inv.id == status.invoice_id
+        # create foreign key join conditions
         fkey_vendor = inv.vendor_id == ven.vendor_id
         fkey_po = (po.po_nbr == inv.po_nbr) & (
             po.release_nbr == inv.release_nbr
         )
 
-        # TODO: remove this section
-        # create a sub-query for recently closed and cancelled invoices
-        # updated_recently = status.status_date > (date.today() - timedelta(45))
-        # closed = sa.select(inv.id)
-        # closed = closed.join(status, fkey_status)
-        # closed = closed.where(inv.status == status.to_status)
-        # closed = closed.where(updated_recently)
-        # closed = closed.cte("recently_closed")  # creates a WITH clause
-        # closed = sa.select(closed.c.id)  # isloates invoice ids from clause
-
-        # create the return query
+        # build the query statement
         query = sa.select(
             # invoice columns and vendor name
             ven.name,
@@ -193,6 +181,8 @@ class CitiBuy:
             (inv.status.not_in(("4IP", "4IC")))
             | (inv.modified > (date.today() - timedelta(45)))
         )
+
+        # execute the query
         with Session(self.engine) as session:
             rows = session.execute(query).fetchall()
         return DatabaseRows(rows)

--- a/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/invoice_tables.py
@@ -15,6 +15,7 @@ class Invoice(db.Base):
     invoice_date = db.Column("INVOICE_DATE", db.DateTime)
     status = db.Column("INVOICE_STATUS", db.String)
     amount = db.Column("INVOICE_AMT", db.Float(precision=2))
+    modified = db.Column("UPDATED_DATE", db.DateTime)
     vendor_id = db.Column(
         "VENDOR_NBR",
         db.String,
@@ -35,6 +36,7 @@ class Invoice(db.Base):
         "status",
         "amount",
         "vendor_id",
+        "modified",
     )
 
 

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -246,6 +246,7 @@ INVOICES = {
         "status": "4IP",
         "amount": 10.25,
         "invoice_date": datetime(2020, 8, 30),
+        "modified": datetime(2020, 8, 30),
     },
     # Acme invoice for DGS, status: Paid
     # Included because it was paid less than 45 days ago
@@ -258,6 +259,7 @@ INVOICES = {
         "status": "4IP",
         "amount": 25.00,
         "invoice_date": datetime(2020, 7, 1),
+        "modified": datetime(2050, 8, 30),
     },
     # Acme invoice for DGS, status: Approved for Payment
     # Included because it hasn't yet been paid
@@ -270,6 +272,7 @@ INVOICES = {
         "status": "4IA",
         "amount": 25.00,
         "invoice_date": datetime(2020, 7, 1),
+        "modified": datetime(2020, 8, 30),
     },
     # Acme invoice for DPW, status: In Progress
     # Excluded because it's for DPW
@@ -282,6 +285,7 @@ INVOICES = {
         "status": "4II",
         "amount": 10.50,
         "invoice_date": datetime(2020, 8, 15),
+        "modified": datetime(2020, 8, 30),
     },
     # Disney invoice for DGS, status: Approved for Payment
     # Included because it hasn't yet been paid
@@ -294,6 +298,7 @@ INVOICES = {
         "status": "4IA",
         "amount": 10.50,
         "invoice_date": datetime(2020, 9, 30),
+        "modified": datetime(2020, 8, 30),
     },
     # Disney invoice for DGS, status: Cancelled
     # Included because it was canceled less than 45 days ago
@@ -306,6 +311,7 @@ INVOICES = {
         "status": "4IC",
         "amount": 5.00,
         "invoice_date": datetime(2020, 7, 1),
+        "modified": datetime(2050, 8, 30),
     },
     # Disney invoice for DGS, status: Cancelled
     # Excluded because it was cancelled more than 45 days ago
@@ -318,6 +324,7 @@ INVOICES = {
         "status": "4IC",
         "amount": 5.00,
         "invoice_date": datetime(2020, 7, 15),
+        "modified": datetime(2020, 8, 30),
     },
     # Disney invoice for DGS, status: In Progress
     # Included because it hasn't yet been paid
@@ -330,6 +337,7 @@ INVOICES = {
         "status": "4II",
         "amount": 10.00,
         "invoice_date": datetime(2020, 8, 1),
+        "modified": datetime(2020, 8, 30),
     },
 }
 


### PR DESCRIPTION
## Summary

Changes how `CitiBuy.get_invoices()` filters for the the set of DGS invoices to export from CitiBuy. The previous query excluded many recently paid invoices.

Fixes #104 

## Changes Proposed

- Adds a `modified` field to the `Invoice` table which represents the date that the invoice was last updated
- Replaces the previous subquery that returned the list of invoice ids whose status had been updated in the last 45 days with a condition that retrieves closed and canceled invoices that had been updated at all in the last 45 days.

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run integration tests `pytest tests/integration_tests/aging_report/`
1. All tests should pass
2. Run the following code which should return some number over 5000
```python
from dgs_fiscal.systems import CitiBuy

citibuy = CitiBuy()
invoices = citibuy.get_invoices()
print(len(invoices.dataframe))
```

