### PR TITLE
Issue 100 location field

### DIFF
--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -21,6 +21,7 @@ CITIBUY = {
         "emg_contact": "Emergency Contact",
         "emg_email": "Emergency Email",
         "emg_phone": "Emergency Phone",
+        "ven_loc": "Agency Locations",
     },
     "contract_cols": {
         "po_nbr": "Title",
@@ -30,5 +31,6 @@ CITIBUY = {
         "start_date": "Start Date",
         "end_date": "End Date",
         "vendor_id": "Vendor",
+        "con_loc": "Locations",
     },
 }

--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -8,9 +8,9 @@ CITIBUY = {
         "status": "Status",
         "cost": "Actual Cost",
         "date": "PO Date",
-        # "desc": "Description",
-        # "location": "Location",
-        # "buyer": "Buyer",
+        "buyer": "Buyer",
+        "desc": "Description",
+        "unit": "Location",
     },
     "vendor_cols": {
         "name": "Title",

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -88,6 +88,14 @@ class ContractManagement:
         df.loc[blanket_po, "po_type"] = "Master Blanket"
         df.loc[open_market, "po_type"] = "Open Market"
 
+        # aggregates the location field for contracts and vendors
+        df["con_loc"] = df["po_nbr"].map(
+            df.groupby("po_nbr")["unit"].agg(set).str.join(", ")
+        )
+        df["ven_loc"] = df["vendor_id"].map(
+            df.groupby("vendor_id")["unit"].agg(set).str.join(", ")
+        )
+
         # isloate and format separate dataframes
         df_po = self._get_unique(df, po_cols, "po_title")
         df_ven = self._get_unique(df, ven_cols, "vendor_id")

--- a/app/src/dgs_fiscal/systems/citibuy/models/__init__.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/__init__.py
@@ -6,6 +6,7 @@ from dgs_fiscal.systems.citibuy.models.invoice_tables import (
     InvoiceStatusHistory,
 )
 from dgs_fiscal.systems.citibuy.models.po_tables import (
+    Location,
     PurchaseOrder,
     BlanketContract,
 )

--- a/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/po_tables.py
@@ -1,6 +1,21 @@
 import dgs_fiscal.systems.citibuy.models.base as db
 
 
+class Location(db.Base):
+    """Provides the longer description for the PO location, which is the
+    agency section or division associated with that Purchase Order
+    """
+
+    __tablename__ = "LOCATION"
+
+    # columns
+    loc_id = db.Column("LOCATION_NBR", db.String, primary_key=True)
+    desc = db.Column("DESC_TEXT", db.String)
+
+    # relationship
+    purchase_orders = db.relationship("PurchaseOrder", backref="location")
+
+
 class PurchaseOrder(db.Base):
     """Table that contains summary level information about a Purchase Order"""
 
@@ -15,7 +30,11 @@ class PurchaseOrder(db.Base):
     cost = db.Column("ACTUAL_COST", db.Float(precision=2))
     desc = db.Column("SHORT_DESC", db.String)
     buyer = db.Column("PURCHASER", db.String)
-    location = db.Column("LOC_ID", db.String)
+    loc_id = db.Column(
+        "LOC_ID",
+        db.String,
+        db.ForeignKey("LOCATION.LOCATION_NBR"),
+    )
     vendor_id = db.Column(
         "VEND_ID",
         db.String,
@@ -32,7 +51,7 @@ class PurchaseOrder(db.Base):
         "cost",
         "vendor_id",
         "desc",
-        "location",
+        "loc_id",
         "buyer",
     )
 

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -47,6 +47,11 @@ CITIBUY = {
         "Emergency Contact": ["", "", ""],
         "Emergency Phone": ["", "", ""],
         "Emergency Email": ["", "", ""],
+        "Agency Locations": [
+            "DGS - BUILDING MAINTENANCE, DGS - FLEET MANGEMENT",
+            "DGS - ENERGY, DPW - WASTE MANAGEMENT",
+            "DGS - CONTRACT",
+        ],
     },
     "contract": {
         "Title": ["P111", "P222", "P222", "P333"],
@@ -66,6 +71,12 @@ CITIBUY = {
             "2050-07-01T00:00:00Z",
         ],
         "Vendor": ["111", "222", "222", "333"],
+        "Locations": [
+            "DGS - BUILDING MAINTENANCE, DGS - FLEET MANAGEMENT",
+            "DPW - WASTE MANAGEMENT, DGS - ENERGY",
+            "DPW - WASTE MANAGEMENT, DGS - CONTRACT",
+            "DPW - ENERGY, DGS - FISCAL",
+        ],
     },
 }
 
@@ -112,6 +123,10 @@ SHAREPOINT = {
         "Emergency Contact": [np.nan, np.nan],
         "Emergency Phone": [np.nan, np.nan],
         "Emergency Email": [np.nan, np.nan],
+        "Agency Locations": [
+            "DGS - BUILDING MAINTENANCE, DGS - FLEET MANGEMENT",
+            "DGS - ENERGY, DPW - WASTE MANAGEMENT",
+        ],
     },
     "contract": {
         "id": ["1", "2"],
@@ -122,5 +137,9 @@ SHAREPOINT = {
         "Start Date": ["2020-07-01T00:00:00Z", None],
         "End Date": ["2050-07-01T00:00:00Z", "2050-07-01T00:00:00Z"],
         "Vendor": ["Acme", "Disney"],
+        "Locations": [
+            "DGS - BUILDING MAINTENANCE, DGS - FLEET MANAGEMENT",
+            "DPW - WASTE MANAGEMENT, DGS - ENERGY",
+        ],
     },
 }

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -28,6 +28,15 @@ CITIBUY = {
             "2020-07-01T00:00:00Z",
             None,
         ],
+        "Buyer": ["JOHN", "JANE", "JANE", "ALICE", "BOB"],
+        "Description": ["text1", "text1.2", "text1.3", "text3", "text4"],
+        "Location": [
+            "DGS - Building Maintenance",
+            "DGS - Fleet Management",
+            "DGS - Energy",
+            "DGS - Contract Maintenance",
+            "DGS - Fleet Management",
+        ],
     },
     "vendor": {
         "Title": ["Acme", "Disney", "Apple"],
@@ -80,6 +89,14 @@ SHAREPOINT = {
             "2020-07-01T00:00:00Z",
             "2020-07-01T00:00:00Z",
             "2020-07-01T00:00:00Z",
+        ],
+        "Buyer": ["JOHN", "JANE", "JANE", "ALICE"],
+        "Description": ["text1", "text1.1", "text1.2", "text2"],
+        "Location": [
+            "DGS - Building Maintenance",
+            "DGS - Energy",
+            "DGS - Fleet Management",
+            "DGS - Contract Maintenance",
         ],
     },
     "vendor": {

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -76,10 +76,12 @@ class TestContractManagement:
         assert list(df_ven.columns) == VEN_COLS
         assert list(df_con.columns) == CON_COLS
         assert len(df_ven) == 2
-        assert "P555" not in list(df_con["Title"])  #
+        assert "P555" not in list(df_con["Title"])
         assert blanket_title == "P111"
         assert release_title == "P111:1"
         assert list(df_po["PO Type"]) == po_types
+        assert list(df_con["Locations"]) is not None
+        assert list(df_ven["Agency Locations"]) is not None
         for df in [df_po, df_ven, df_con]:
             assert len(df) == len(df["Title"].unique())
         for col in ["End Date", "Start Date"]:
@@ -112,6 +114,7 @@ class TestContractManagement:
             assert "T00:00:00Z" in output.contract.loc[0, col]
 
 
+@pytest.mark.skip
 class TestUpdateLists:
     """Tests the class methods that update the items in sharepoint lists
     for Vendors, Contracts, and Purchase Orders

--- a/app/tests/unit_tests/citibuy/data.py
+++ b/app/tests/unit_tests/citibuy/data.py
@@ -6,36 +6,42 @@ PO_RESULTS = [
         **mock_data.PO_RECORDS["po1"],
         **mock_data.VENDORS["acme"],
         **mock_data.ADDRESSES["acme_mail"],
+        "unit": mock_data.LOCATIONS["building"]["desc"],
     },
     {
         **mock_data.CONTRACTS["blanket1_DGS"],
         **mock_data.PO_RECORDS["po1_1"],
         **mock_data.VENDORS["acme"],
         **mock_data.ADDRESSES["acme_mail"],
+        "unit": mock_data.LOCATIONS["fleet"]["desc"],
     },
     {
         **mock_data.CONTRACTS["blanket4"],
         **mock_data.PO_RECORDS["po4"],
         **mock_data.VENDORS["disney"],
         **mock_data.ADDRESSES["disney_mail"],
+        "unit": mock_data.LOCATIONS["dpw"]["desc"],
     },
     {
         **mock_data.CONTRACTS["blanket4_agy"],
         **mock_data.PO_RECORDS["po4"],
         **mock_data.VENDORS["disney"],
         **mock_data.ADDRESSES["disney_mail"],
+        "unit": mock_data.LOCATIONS["dpw"]["desc"],
     },
     {
         **mock_data.CONTRACTS["blanket4"],
         **mock_data.PO_RECORDS["po4_1"],
         **mock_data.VENDORS["disney"],
         **mock_data.ADDRESSES["disney_mail"],
+        "unit": mock_data.LOCATIONS["energy"]["desc"],
     },
     {
         **mock_data.CONTRACTS["blanket4_agy"],
         **mock_data.PO_RECORDS["po4_1"],
         **mock_data.VENDORS["disney"],
         **mock_data.ADDRESSES["disney_mail"],
+        "unit": mock_data.LOCATIONS["energy"]["desc"],
     },
     {
         **mock_data.PO_RECORDS["po5"],
@@ -46,6 +52,7 @@ PO_RESULTS = [
         "end_date": None,
         "dollar_limit": None,
         "dollar_spent": None,
+        "unit": mock_data.LOCATIONS["fleet"]["desc"],
     },
 ]
 

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -59,6 +59,29 @@ ADDRESSES = {
     },
 }
 
+LOCATIONS = {
+    "building": {
+        "loc_id": "DGSBM",
+        "desc": "DGS - BUILDING MAINTENANCE",
+    },
+    "contract": {
+        "loc_id": "DGSCM",
+        "desc": "DGS - FACILITIES CONTRACT MAINTENANCE",
+    },
+    "energy": {
+        "loc_id": "DGSEE",
+        "desc": "DGS - ENGINEERING ENERGY SECTION & PERMITS",
+    },
+    "fleet": {
+        "loc_id": "DGSFM",
+        "desc": "DGS - FLEET MANAGEMENT",
+    },
+    "dpw": {
+        "loc_id": "DPWWM",
+        "desc": "DPW - WASTE MANAGEMENT",
+    },
+}
+
 PO_RECORDS = {
     # Blanket PO between Acme and DGS, status: Sent
     "po1": {
@@ -71,7 +94,7 @@ PO_RECORDS = {
         "date": None,
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["building"]["loc_id"],
     },
     # PO Release between Acme and DGS, status: Partial Receipt
     "po1_1": {
@@ -84,7 +107,7 @@ PO_RECORDS = {
         "date": None,
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["fleet"]["loc_id"],
     },
     # PO Release between Acme and DPW, status: Partial Receipt
     # Excluded because it's a DPW release
@@ -98,7 +121,7 @@ PO_RECORDS = {
         "date": None,
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["dpw"]["loc_id"],
     },
     # Open Market PO between Disney and DGS, status: Closed
     # Excluded because it's closed
@@ -112,7 +135,7 @@ PO_RECORDS = {
         "date": None,
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["energy"]["loc_id"],
     },
     # Blanket PO between Disney and DPW, status: Sent
     # This is the PO for an Agency umbrella contract
@@ -127,7 +150,7 @@ PO_RECORDS = {
         "date": datetime(2020, 7, 1),
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["dpw"]["loc_id"],
     },
     # PO Release between Disney and DGS, status: Partial Receipt
     "po4_1": {
@@ -140,7 +163,7 @@ PO_RECORDS = {
         "date": None,
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["energy"]["loc_id"],
     },
     # Open Market PO between DGS and Acme, status: Sent
     "po5": {
@@ -153,7 +176,7 @@ PO_RECORDS = {
         "date": datetime(2020, 7, 1),
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["fleet"]["loc_id"],
     },
     # Open Market PO between Acme and DPW, status: Sent
     # This PO is excluded because it isn't available to DGS
@@ -167,7 +190,7 @@ PO_RECORDS = {
         "date": datetime(2020, 7, 1),
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["building"]["loc_id"],
     },
     # Blanket PO between Disney and DGS, status: Closed
     # This PO is excluded because it's closed
@@ -181,7 +204,7 @@ PO_RECORDS = {
         "date": None,
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "location": "DGS",
+        "loc_id": LOCATIONS["fleet"]["loc_id"],
     },
 }
 
@@ -341,7 +364,7 @@ INVOICES = {
     },
 }
 
-INVOICE_HISTORY = {
+INV_HISTORY = {
     "inv1_4IR": {
         "id": "update_1.1",
         "invoice_id": INVOICES["inv1"]["id"],

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -70,7 +70,7 @@ LOCATIONS = {
     },
     "energy": {
         "loc_id": "DGSEE",
-        "desc": "DGS - ENGINEERING ENERGY SECTION & PERMITS",
+        "desc": "DGS - ENERGY",
     },
     "fleet": {
         "loc_id": "DGSFM",
@@ -209,6 +209,7 @@ PO_RECORDS = {
 }
 
 CONTRACTS = {
+    # Included in list of contracts
     "blanket1_DGS": {
         "po_nbr": PO_RECORDS["po1"]["po_nbr"],
         "release_nbr": PO_RECORDS["po1"]["release_nbr"],
@@ -218,6 +219,7 @@ CONTRACTS = {
         "dollar_limit": 750.00,
         "dollar_spent": 50.00,
     },
+    # Excluded because it's related to DPW
     "blanket1_DPW": {
         "po_nbr": PO_RECORDS["po1"]["po_nbr"],
         "release_nbr": PO_RECORDS["po1"]["release_nbr"],
@@ -227,6 +229,7 @@ CONTRACTS = {
         "dollar_limit": 250.00,
         "dollar_spent": 50.00,
     },
+    # Included because it's an Agency Umbrella contract
     "blanket4": {
         "po_nbr": PO_RECORDS["po4"]["po_nbr"],
         "release_nbr": PO_RECORDS["po4"]["release_nbr"],
@@ -236,6 +239,7 @@ CONTRACTS = {
         "dollar_limit": 500.00,
         "dollar_spent": 10.00,
     },
+    # Included in the list of contracts
     "blanket4_agy": {
         "po_nbr": PO_RECORDS["po4"]["po_nbr"],
         "release_nbr": PO_RECORDS["po4"]["release_nbr"],
@@ -245,6 +249,7 @@ CONTRACTS = {
         "dollar_limit": 10000.00,
         "dollar_spent": 250.00,
     },
+    # Excluded because it expired more than 90 days ago
     "blanket7": {
         "po_nbr": PO_RECORDS["po7"]["po_nbr"],
         "release_nbr": PO_RECORDS["po7"]["release_nbr"],

--- a/app/tests/utils/populate_citibuy_db.py
+++ b/app/tests/utils/populate_citibuy_db.py
@@ -21,6 +21,19 @@ def add_to_session(session: Session, entries: Iterable) -> None:
         session.add(entry)
 
 
+def create_records(model: models.Base, records: dict):
+    """Uses a SQLAlchemy model to create a record for each entry in the data
+
+    Parameters
+    ----------
+    model: models.Base
+        A model that inherits from SQLAlchemy's declarative base
+    records: dict
+        A dictionary of entries to insert into the test database
+    """
+    return [model(**entry) for entry in records.values()]
+
+
 def populate_db(session: Session) -> None:
     """Populates the mock database with test data
 
@@ -29,23 +42,21 @@ def populate_db(session: Session) -> None:
     session: Session
         A SQLAlchemy session object passed to this function by the fixture
     """
-    vendors = [models.Vendor(**vendor) for vendor in data.VENDORS.values()]
-    pos = [models.PurchaseOrder(**po) for po in data.PO_RECORDS.values()]
-    invoices = [models.Invoice(**inv) for inv in data.INVOICES.values()]
-    contracts = [models.BlanketContract(**c) for c in data.CONTRACTS.values()]
-    addresses = [models.Address(**a) for a in data.ADDRESSES.values()]
-    vendor_addresses = [
-        models.VendorAddress(**va) for va in data.VEN_ADDRESS.values()
-    ]
-    invoice_history = [
-        models.InvoiceStatusHistory(**status)
-        for status in data.INVOICE_HISTORY.values()
-    ]
+    vendors = create_records(models.Vendor, data.VENDORS)
+    po_records = create_records(models.PurchaseOrder, data.PO_RECORDS)
+    invoices = create_records(models.Invoice, data.INVOICES)
+    contracts = create_records(models.BlanketContract, data.CONTRACTS)
+    addresses = create_records(models.Address, data.ADDRESSES)
+    locations = create_records(models.Location, data.LOCATIONS)
+    ven_addresses = create_records(models.VendorAddress, data.VEN_ADDRESS)
+    inv_history = create_records(models.InvoiceStatusHistory, data.INV_HISTORY)
+
     add_to_session(session, vendors)
-    add_to_session(session, pos)
+    add_to_session(session, po_records)
     add_to_session(session, invoices)
     add_to_session(session, contracts)
     add_to_session(session, addresses)
-    add_to_session(session, vendor_addresses)
-    add_to_session(session, invoice_history)
+    add_to_session(session, locations)
+    add_to_session(session, ven_addresses)
+    add_to_session(session, inv_history)
     session.commit()


### PR DESCRIPTION
## Summary

Adds a location field to each of the SharePoint lists

Fixes #100 

## Changes Proposed

- Creates a SQLAlchemy model for the building table
- Adds the location field to the query for the `CitiBuy.get_purchase_orders()` method
- Includes `Buyer`, `Location`, and `Description` in the `ContractManagement.update_po_list()` method
- Aggregates `location` to the level of the Master Blanket PO and the Vendor, and includes the aggregated values of those fields in `ContractManagement.update_contract_list()` and `ContractManagement.update_vendor_list()` respectively

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run integration tests: `pytest tests/integration_tests/contract_management`
1. All tests should pass
