### PR TITLE
Issue 98 upload invoice data

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # runs checks on each of the following python versions
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The list below represents a summary of important files and directories within th
 
 ### Prerequisites
 
-- Python installed on your local machine, preferably a version between 3.7 and 3.9
+- Python installed on your local machine, preferably a version between 3.8 and 3.9
 
 In order to check which version of python you have installed, run the following in your command line, and the output should look something like this:
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,3 +18,4 @@ sqlalchemy==1.4.25
 pyodbc==4.0.32
 more-itertools==8.11.0
 typer==0.4.0
+XlsxWriter==3.0.2

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -19,3 +19,4 @@ pyodbc==4.0.32
 more-itertools==8.11.0
 typer==0.4.0
 XlsxWriter==3.0.2
+numpy==1.22.1

--- a/app/setup.py
+++ b/app/setup.py
@@ -20,6 +20,7 @@ setup(
         "openpyxl",
         "more-itertools",
         "typer",
+        "XlsxWriter",
     ],
     include_package_data=True,
     package_dir={"": "src"},  # this is required to access code in src/

--- a/app/src/dgs_fiscal/systems/sharepoint/archive.py
+++ b/app/src/dgs_fiscal/systems/sharepoint/archive.py
@@ -26,6 +26,47 @@ class ArchiveFolder:
         self.archive_dir = archive_dir or (Path.cwd() / "archives")
         self.tmp_dir = self.archive_dir / "tmp"
         self.subfolders = list(self.folder.get_child_folders())
+        self.tmp_dir.mkdir(exist_ok=True, parents=True)
+
+    def export_dataframe(
+        self,
+        df: pd.DataFrame,
+        file_name: str,
+    ) -> Path:
+        """Export dataframe to Excel in local archive for uploade to SharePoint
+        and styles the data as a table
+
+        Parameters
+        ----------
+        df: pd.DataFrame
+            The dataframe to export to Excel
+        file_name: str
+            File name to save to save the exported dataframe under
+
+        Returns
+        -------
+        Path
+            Path to where the dataframe was saved as an Excel file
+        """
+        # set the export location to local tmp_dir
+        file = self.tmp_dir / file_name
+
+        # write the data to Excel and get the worksheet using XlsxWriter
+        writer = pd.ExcelWriter(  # pylint: disable=abstract-class-instantiated
+            file, engine="xlsxwriter"
+        )
+        df.to_excel(writer, sheet_name="Sheet1", index=False)
+        worksheet = writer.sheets["Sheet1"]
+
+        # format the data as a table and adjust col width
+        (max_row, max_col) = df.shape
+        columns = [{"header": column} for column in df.columns]
+        worksheet.add_table(0, 0, max_row, max_col - 1, {"columns": columns})
+        worksheet.set_column(0, max_col - 1, 12)
+
+        # save the file and return the path
+        writer.save()
+        return file
 
     def upload_file(
         self,
@@ -43,7 +84,7 @@ class ArchiveFolder:
             Name of the sub-folder in the archive where the file will be
             uploaded. Must be one of the folders in self.subfolders
         file_name: str
-            What to name of the file once it's uploaded
+            What to name of the file once it"s uploaded
         """
         # check that the upload file exists
         if not local_path.exists():
@@ -68,7 +109,7 @@ class ArchiveFolder:
         download_path: Path
             Local path to where file will be downloaded
         download_name: str, optional
-            What to name the file when it's downloaded. Default is to use the
+            What to name the file when it"s downloaded. Default is to use the
             existing name of the file in SharePoint
 
         Returns

--- a/app/tests/integration_tests/aging_report/test_main.py
+++ b/app/tests/integration_tests/aging_report/test_main.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 import pandas as pd
 
@@ -47,3 +49,23 @@ class TestAgingReport:
         assert output.columns.all() == expected.columns.all()
         for val in output["Status"]:
             assert val in mock_aging.citibuy.INVOICE_STATUS.values()
+
+    def test_upload_invoice_data(self, mock_aging, test_archive_dir):
+        """Tests that upload_invoice_data() method executes correctly
+
+        Validates the following conditions:
+        - The file has been uploaded to SharePoint
+        - The filename that is uploaded contains today's date
+        """
+        # setup
+        date_str = datetime.today().strftime("%Y-%m-%d")
+        file_name = f"{date_str}_InvoiceExport.xlsx"
+        df = pd.DataFrame({"Col A": ["a", "b"], "Col B": ["d", "f"]})
+        # execution
+        file = mock_aging.upload_invoice_data(
+            df=df,
+            folder_name="test",
+            local_archive=test_archive_dir,
+        )
+        # validation
+        assert file.name == file_name

--- a/app/tests/integration_tests/sharepoint/test_archive.py
+++ b/app/tests/integration_tests/sharepoint/test_archive.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import pandas as pd
 from O365.drive import Folder, File
 
 DATA_DIR = Path.cwd() / "tests" / "integration_tests" / "sharepoint" / "data"
@@ -96,3 +97,14 @@ class TestArchiveFolder:
         assert isinstance(output, Path)
         assert output.name == file_name
         assert any(tmp_dir.iterdir())
+
+    def test_export_dataframe(self, test_archive):
+        """Tests that the export_dataframe() method successfully exports the
+        dataframe to an Excel file and formats it with a table
+        """
+        # setup
+        df = pd.DataFrame({"Col A": ["a", "b"], "Col B": ["d", "f"]})
+        # execution
+        file = test_archive.export_dataframe(df, "test.xlsx")
+        # validation
+        assert file.exists()

--- a/app/tox.ini
+++ b/app/tox.ini
@@ -12,7 +12,9 @@ commands = black src tests
 
 [testenv:checkdeps]
 deps = -rrequirements.txt
-commands = safety check
+# TODO: Remove this ignore when this issue is resolved:
+# https://github.com/numpy/numpy/issues/19038
+commands = safety check --ignore 44715
            liccheck
 
 [testenv:pytest]

--- a/app/tox.ini
+++ b/app/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, lint, checkdeps, pytest
+envlist = py38, py39, lint, checkdeps, pytest
 skipsdist = false
 skip_missing_interpreters = true
 


### PR DESCRIPTION
## Summary

Implements the `AgingReport.upload_invoice_data()` method

Fixes #98 

## Changes Proposed

- Creates an `Archive.export_dataframe()` method to export a dataframe to an Excel file in local directory
- Implements `AgingReport.upload_invoice_data()` method
- Ignores issue 44715 in safety check, which is covered in [this GitHub issue](https://github.com/pyupio/safety/issues/364)
- Pins `numpy==1.22.1` in `requirements.txt` to avoid failing the safety check for versions below 1.22.0

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the integration tests for Aging Report: `pytest tests/integration_tests/aging_report/`
1. All tests should pass
