### PR TITLE
Issue 112 extend invoice date range

### DIFF
--- a/app/src/dgs_fiscal/etl/aging_report/main.py
+++ b/app/src/dgs_fiscal/etl/aging_report/main.py
@@ -39,9 +39,9 @@ class AgingReport:
         pd.DataFrame
             A dataframe of the invoices exported from CitiBuy
         """
-        # query the data from city
-        cols = constants.CITIBUY["invoice_cols"]
-        df = self.citibuy.get_invoices().dataframe
+        # query the data from city,
+        # including invoices paid or cancelled up to a year ago
+        df = self.citibuy.get_invoices(days_ago=365).dataframe
 
         # add PO type column
         open_market = df["contract_end_date"].isna()
@@ -49,6 +49,7 @@ class AgingReport:
         df.loc[open_market, "po_type"] = "Open Market"
 
         # reorder and rename the columns
+        cols = constants.CITIBUY["invoice_cols"]
         df = df[cols.keys()]
         df.columns = cols.values()
 

--- a/app/src/dgs_fiscal/etl/aging_report/main.py
+++ b/app/src/dgs_fiscal/etl/aging_report/main.py
@@ -31,8 +31,14 @@ class AgingReport:
         self.citibuy = CitiBuy(conn_url=citibuy_url)
         self.sharepoint = SharePoint()
 
-    def get_citibuy_data(self) -> pd.DataFrame:
+    def get_citibuy_data(self, invoice_window: int = 365) -> pd.DataFrame:
         """Exports open and recently paid invoices from CitiBuy
+
+        Parameters
+        ----------
+        invoice_window: int
+            The maximum number of days in the past an invoice must have been
+            paid or cancelled in order to be included in the exported results
 
         Returns
         -------
@@ -41,7 +47,7 @@ class AgingReport:
         """
         # query the data from city,
         # including invoices paid or cancelled up to a year ago
-        df = self.citibuy.get_invoices(days_ago=365).dataframe
+        df = self.citibuy.get_invoices(days_ago=invoice_window).dataframe
 
         # add PO type column
         open_market = df["contract_end_date"].isna()

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -34,7 +34,7 @@ class ContractManagement:
         self,
         citibuy_url: str = None,
         vendor_list: str = "Vendors",
-        po_list: str = "Purchase Orders",
+        po_list: str = "PO Releases",
         contract_list: str = "Master Blanket POs",
     ) -> None:
         """Inits the ContractManagement class"""

--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -151,8 +151,15 @@ class CitiBuy:
             rows = session.execute(query).fetchall()
         return DatabaseRows(rows)
 
-    def get_invoices(self) -> DatabaseRows:
+    def get_invoices(self, days_ago: int = 90) -> DatabaseRows:
         """Gets a list of invoices from CitiBuy
+
+        Parameters
+        ----------
+        days_ago: int
+            The maximum number of days in the past an invoice must have been
+            paid or cancelled in order for it to appear in the results. Older
+            paid or cancelled invoices will be excluded
 
         Returns
         -------
@@ -196,8 +203,9 @@ class CitiBuy:
         query = query.where(po.agency == "DGS")  # invoice created from DGS PO
         query = query.where(
             # invoice still open or recently closed or cancelled
+            # as determined by the days_ago parameter cutoff
             (inv.status.not_in(("4IP", "4IC")))
-            | (inv.modified > (date.today() - timedelta(45)))
+            | (inv.modified > (date.today() - timedelta(days_ago)))
         )
 
         # execute the query

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -21,7 +21,7 @@ def fixture_contract(mock_db):
     """Mocks the ContractManagement class with the local CitiBuy db"""
     contract = ContractManagement(
         citibuy_url=mock_db,
-        po_list="Purchase Orders Test",
+        po_list="PO Releases Test",
         vendor_list="Vendors Test",
         contract_list="Master Blanket POs Test",
     )

--- a/app/tests/unit_tests/citibuy/test_client.py
+++ b/app/tests/unit_tests/citibuy/test_client.py
@@ -27,7 +27,7 @@ class TestGetPurchaseOrders:
     """Tests the CitiBuy.get_purchase_orders() method"""
 
     def test_query_default(self, mock_citibuy):
-        """Tests that PurchaseOrders.get_records() returns all records when no
+        """Tests that CitiBuy.get_purchase_orders() returns all records when no
         values are passed to the filter or limit paramaters
 
         Validates the following conditions:
@@ -52,7 +52,7 @@ class TestGetPurchaseOrders:
 
     def test_get_records_limit(self, mock_citibuy):
         """Tests that the limit parameter works as expected when passed to
-        PurchaseOrder.get_records()
+        CitiBuy.get_purchase_orders()
 
         Validates the following conditions:
         - Only the first x records are returned when a limit of x is passed
@@ -73,7 +73,7 @@ class TestGetInvoices:
     """Tests the CitiBuy.get_invoices() method"""
 
     def test_query_default(self, mock_citibuy):
-        """Tests that PurchaseOrders.get_records() returns all records when no
+        """Tests that CitiBuy.get_invoices() returns all records when no
         values are passed to the filter or limit paramaters
 
         Validates the following conditions:
@@ -102,3 +102,23 @@ class TestGetInvoices:
             if col == "po_type":
                 continue
             assert col in output_cols
+
+    def test_query_custom_date_range(self, mock_citibuy):
+        """Tests that CitiBuy.get_invoices() returns more records when the
+        days_ago parameter is passed a large value
+
+        Validates the following conditions:
+        - The results exclude invoices that were cancelled or paid up to 5000
+          days ago
+        """
+        # setup
+        filtered = data.INVOICE_RESULTS
+        old_invoice = "invoice1"  # an invoice paid more than 90 days ago
+        # execution
+        output = mock_citibuy.get_invoices(days_ago=5000).records
+        invoice_ids = [record["id"] for record in output]
+        print("OUTPUT")
+        pprint(output)
+        # validation
+        assert len(output) >= len(filtered)  # ensure more results are returned
+        assert old_invoice in invoice_ids


### PR DESCRIPTION
## Summary

Creates a `days_ago` parameter for `CitiBuy.get_invoices()` to allow users to dynamically extend the date range for paid and cancelled invoices that are returned by the method.

Fixes #112 

## Changes Proposed

- Changes the name of the `Purchase Orders` SharePoint list to `PO Releases`
- Adds the `days_ago` parameter to support dynamic date ranges for paid and cancelled work orders
- Changes the date range for paid and cancelled invoices to 365 days (from 45 days) in `AgingReport.get_citibuy_data()`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run the unit tests: `pytest`
2. All tests should pass
1. Run the integration tests for Aging Report: `pytest tests/integration_tests/aging_report/`
2. All tests should pass
