### PR TITLE
Issue 114 add po buyer and desc

### DIFF
--- a/app/src/dgs_fiscal/etl/contract_management/constants.py
+++ b/app/src/dgs_fiscal/etl/contract_management/constants.py
@@ -32,5 +32,7 @@ CITIBUY = {
         "end_date": "End Date",
         "vendor_id": "Vendor",
         "con_loc": "Locations",
+        "buyer": "Buyer",
+        "desc": "Description",
     },
 }

--- a/app/src/dgs_fiscal/etl/contract_management/main.py
+++ b/app/src/dgs_fiscal/etl/contract_management/main.py
@@ -89,11 +89,13 @@ class ContractManagement:
         df.loc[open_market, "po_type"] = "Open Market"
 
         # aggregates the location field for contracts and vendors
+        # excluding all non DGS locations
+        dgs_po = df["agency"] == "DGS"  # excludes non-DGS POs
         df["con_loc"] = df["po_nbr"].map(
-            df.groupby("po_nbr")["unit"].agg(set).str.join(", ")
+            df[dgs_po].groupby("po_nbr")["unit"].agg(set).str.join(", ")
         )
         df["ven_loc"] = df["vendor_id"].map(
-            df.groupby("vendor_id")["unit"].agg(set).str.join(", ")
+            df[dgs_po].groupby("vendor_id")["unit"].agg(set).str.join(", ")
         )
 
         # isloate and format separate dataframes

--- a/app/src/dgs_fiscal/systems/citibuy/client.py
+++ b/app/src/dgs_fiscal/systems/citibuy/client.py
@@ -39,6 +39,15 @@ class CitiBuy:
         "3PCR": "3PCR - Completed Receipt",
         "3PCO": "3PCO - Closed",
     }
+    DGS_LOCATIONS = [
+        "DGS - BUILDING MAINTENANCE",
+        "DGS - FACILITIES CONTRACT MAINTENANCE",
+        "DGS - FACILITIES DOWNTOWN",
+        "DGS - FACILITIES SHOP",
+        "DGS - FISCAL SECTION",
+        "DGS - FLEET MANAGEMENT",
+        "MAJOR PROJECTS",
+    ]
 
     def __init__(
         self,

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -77,6 +77,8 @@ CITIBUY = {
             "DPW - WASTE MANAGEMENT, DGS - CONTRACT",
             "DPW - ENERGY, DGS - FISCAL",
         ],
+        "Buyer": ["JANEDOE", "JANEDOE", "JANEDOE", "JANEDOE"],
+        "Description": ["text", "text", "text", "text"],
     },
 }
 
@@ -141,5 +143,7 @@ SHAREPOINT = {
             "DGS - BUILDING MAINTENANCE, DGS - FLEET MANAGEMENT",
             "DPW - WASTE MANAGEMENT, DGS - ENERGY",
         ],
+        "Buyer": ["JANEDOE", "JANEDOE"],
+        "Description": ["text", "text"],
     },
 }

--- a/app/tests/integration_tests/contract_management/data.py
+++ b/app/tests/integration_tests/contract_management/data.py
@@ -73,9 +73,9 @@ CITIBUY = {
         "Vendor": ["111", "222", "222", "333"],
         "Locations": [
             "DGS - BUILDING MAINTENANCE, DGS - FLEET MANAGEMENT",
-            "DPW - WASTE MANAGEMENT, DGS - ENERGY",
-            "DPW - WASTE MANAGEMENT, DGS - CONTRACT",
-            "DPW - ENERGY, DGS - FISCAL",
+            "DGS - ENERGY",
+            "DGS - CONTRACT",
+            "DGS - ENERGY, DGS - FISCAL",
         ],
         "Buyer": ["JANEDOE", "JANEDOE", "JANEDOE", "JANEDOE"],
         "Description": ["text", "text", "text", "text"],
@@ -141,7 +141,7 @@ SHAREPOINT = {
         "Vendor": ["Acme", "Disney"],
         "Locations": [
             "DGS - BUILDING MAINTENANCE, DGS - FLEET MANAGEMENT",
-            "DPW - WASTE MANAGEMENT, DGS - ENERGY",
+            "DGS - ENERGY",
         ],
         "Buyer": ["JANEDOE", "JANEDOE"],
         "Description": ["text", "text"],

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -47,7 +47,7 @@ class TestContractManagement:
         - The return type is ContractData
         - The columns of ContractData.po match the CITIBUY constants
         - The columns of ContractData.vendor match the CITIBUY constants
-        - The dataframe in ContractData.vendor has been deduped
+        - The columns of ContractData.contract match the CITIBUY constants
         - The PO Type has been set correctly
         - The list of contracts excludes Open Market POs
         - The list of records in each dataframe is unique
@@ -70,22 +70,25 @@ class TestContractManagement:
         print(df_con)
         blanket_title = df_po.loc[0, "Title"]
         release_title = df_po.loc[1, "Title"]
-        # validation
+        # validation - all of the correct columns are returned
         assert isinstance(output, ContractData)
         assert list(df_po.columns) == PO_COLS
         assert list(df_ven.columns) == VEN_COLS
         assert list(df_con.columns) == CON_COLS
-        assert len(df_ven) == 2
-        assert "P555" not in list(df_con["Title"])
+        # validation - data transformations were done correctly
+        assert "P555" not in list(df_con["Title"])  # open market PO excluded
         assert blanket_title == "P111"
         assert release_title == "P111:1"
         assert list(df_po["PO Type"]) == po_types
-        assert list(df_con["Locations"]) is not None
-        assert list(df_ven["Agency Locations"]) is not None
-        for df in [df_po, df_ven, df_con]:
-            assert len(df) == len(df["Title"].unique())
         for col in ["End Date", "Start Date"]:
             assert "T00:00:00Z" in df_con.loc[0, col]
+        # validation - PO locations were aggregated correctly
+        assert list(df_con["Locations"]) is not None
+        assert list(df_ven["Agency Locations"]) is not None
+
+        # validation - rows were successfully deduped
+        for df in [df_po, df_ven, df_con]:
+            assert len(df) == len(df["Title"].unique())
 
     def test_get_sharepoint_data(self, mock_contract):
         """Tests the get_sharepoint_data() method executes correctly

--- a/app/tests/integration_tests/contract_management/test_main.py
+++ b/app/tests/integration_tests/contract_management/test_main.py
@@ -68,6 +68,8 @@ class TestContractManagement:
         print(df_po)
         print(df_ven)
         print(df_con)
+        print(df_con["Locations"])
+        print(df_ven["Agency Locations"])
         blanket_title = df_po.loc[0, "Title"]
         release_title = df_po.loc[1, "Title"]
         # validation - all of the correct columns are returned
@@ -85,7 +87,7 @@ class TestContractManagement:
         # validation - PO locations were aggregated correctly
         assert list(df_con["Locations"]) is not None
         assert list(df_ven["Agency Locations"]) is not None
-
+        assert len(df_con[df_con["Locations"].str.contains("DPW")]) == 0
         # validation - rows were successfully deduped
         for df in [df_po, df_ven, df_con]:
             assert len(df) == len(df["Title"].unique())

--- a/app/tests/unit_tests/citibuy/data.py
+++ b/app/tests/unit_tests/citibuy/data.py
@@ -54,7 +54,7 @@ PO_RESULTS = [
         "end_date": None,
         "dollar_limit": None,
         "dollar_spent": None,
-        "unit": mock_data.LOCATIONS["fleet"]["desc"],
+        "unit": mock_data.LOCATIONS["contract"]["desc"],
     },
 ]
 

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -176,7 +176,7 @@ PO_RECORDS = {
         "date": datetime(2020, 7, 1),
         "buyer": "JOHNSMITH",
         "desc": "description",
-        "loc_id": LOCATIONS["fleet"]["loc_id"],
+        "loc_id": LOCATIONS["contract"]["loc_id"],
     },
     # Open Market PO between Acme and DPW, status: Sent
     # This PO is excluded because it isn't available to DGS


### PR DESCRIPTION
## Summary

Adds Buyer and Description to the list of fields that are updated on the Master Blanket POs SharePoint list. Additionally removes non-DGS locations from the list of PO locations that are aggregated at the Vendor and the Master Blanket PO level.

Fixes #114 

## Changes Proposed

- Adds `Buyer` and `Description` to the list of fields that are updated automatically on the Master Blanket PO SharePoint list each time the Contract Management ETL is run.
- Changes the way that PO locations are aggregated at the Master Blanket PO and Vendor level so that all non-DGS locations (e.g. DPW, BOP, etc.) are excluded from aggregation

## Additional Context

- This will take a long time to update the next time time the Contract Management ETL is run because many of the location fields will need to be updated
- Even after updating, som Vendors and Master Blanket POs will still have non-DGS locations if those Vendors don't have active POs or if those Master Blanket POs have expired

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run unit tests: `pytest`
1. All tests should pass
2. Run integration tests for Contract Management: `pytest tests/integration_tests/contract_management/`
3. All tests should pass
