### PR TITLE
Issue 120 update sharepoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.defaultInterpreterPath": "app/env/bin/python",
+    "python.analysis.extraPaths": [
+        "app"
+    ]
+}

--- a/app/src/dgs_fiscal/etl/aging_report/main.py
+++ b/app/src/dgs_fiscal/etl/aging_report/main.py
@@ -137,9 +137,10 @@ class AgingReport:
         df = df.fillna("")
         return df
 
-    def upload_invoice_data(
+    def update_sharepoint(
         self,
         df: pd.DataFrame,
+        report_name: str,
         folder_name: Optional[str] = None,
         local_archive: Optional[Path] = None,
     ) -> File:
@@ -163,7 +164,7 @@ class AgingReport:
         """
         # set the file name to the current date
         date_str = datetime.today().strftime("%Y-%m-%d")
-        file_name = f"{date_str}_InvoiceExport.xlsx"
+        file_name = f"{date_str}_{report_name}.xlsx"
 
         # export the invoice data to local archive
         archive = self.sharepoint.get_archive_folder(local_archive)
@@ -171,5 +172,4 @@ class AgingReport:
 
         # upload the exported file to SharePoint
         folder = folder_name or "aging_report"
-        print(folder)
         return archive.upload_file(tmp_file, folder, file_name)

--- a/app/tests/integration_tests/aging_report/test_main.py
+++ b/app/tests/integration_tests/aging_report/test_main.py
@@ -53,7 +53,8 @@ class TestAgingReport:
         for val in output["PO Status"]:
             assert val in mock_aging.citibuy.PO_STATUS.values()
 
-    def test_upload_invoice_data(self, mock_aging, test_archive_dir):
+    @pytest.mark.parametrize("file_name", ["InvoiceExport", "AgingReport"])
+    def test_update_sharepoint(self, file_name, mock_aging, test_archive_dir):
         """Tests that upload_invoice_data() method executes correctly
 
         Validates the following conditions:
@@ -62,16 +63,17 @@ class TestAgingReport:
         """
         # setup
         date_str = datetime.today().strftime("%Y-%m-%d")
-        file_name = f"{date_str}_InvoiceExport.xlsx"
+        expected_name = f"{date_str}_{file_name}.xlsx"
         df = pd.DataFrame({"Col A": ["a", "b"], "Col B": ["d", "f"]})
         # execution
-        file = mock_aging.upload_invoice_data(
+        file = mock_aging.update_sharepoint(
             df=df,
+            report_name=file_name,
             folder_name="test",
             local_archive=test_archive_dir,
         )
         # validation
-        assert file.name == file_name
+        assert file.name == expected_name
 
 
 class TestGetSharePointData:
@@ -139,3 +141,14 @@ class TestPopulateReport:
         print(output.to_dict("records"))
         # validation
         assert output.to_dict("records") == expected.to_dict("records")
+
+
+class TestUpdateSharePoint:
+    """Tests the AgingReport.update_sharepoint() method"""
+
+    def test_update_sharepoint(self, mock_aging):
+        """Tests that update_sharepoint() method executes correctly
+
+        Validates the following conditions:
+        -
+        """


### PR DESCRIPTION
## Summary

Replaces `AgingReport.upload_invoice_data()` with `AgingReport.update_sharepoint()`

Fixes #120 

## Changes Proposed

- Adds `.vscode/settings.json` to set the python interpreter for VS Code
- Replaces `AgingReport.upload_invoice_data()` with `AgingReport.update_sharepoint()` and adds a new required parameter `report_name`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run unit tests: `pytest` all tests should pass.
1. Run integration tests: `pytest tests/integration_tests/aging_report` all tests should pass.
