### PR TITLE
Issue 127 add receipt queue window

### DIFF
--- a/app/src/dgs_fiscal/etl/aging_report/main.py
+++ b/app/src/dgs_fiscal/etl/aging_report/main.py
@@ -70,7 +70,7 @@ class AgingReport:
 
         return df
 
-    def get_receipt_queue(self) -> pd.DataFrame:
+    def get_receipt_queue(self, receipt_window: int = 365) -> pd.DataFrame:
         """Exports unapproved receipts from CitiBuy
 
         Returns
@@ -78,9 +78,9 @@ class AgingReport:
         pd.DataFrame
             A dataframe of the receipts exported from CitiBuy
         """
-        # query the receipts not yet approved
+        # query receipts not yet approved or approved within the last year
         # and the people listed in the approval path
-        df = self.citibuy.get_receipts().dataframe
+        df = self.citibuy.get_receipts(days_ago=receipt_window).dataframe
 
         # reorder and rename the columns
         cols = constants.CITIBUY["receipt_cols"]

--- a/app/src/dgs_fiscal/systems/citibuy/models/receipt_tables.py
+++ b/app/src/dgs_fiscal/systems/citibuy/models/receipt_tables.py
@@ -18,6 +18,7 @@ class Receipt(db.Base):
     agency = db.Column("DEPT_NBR_PREFIX", db.String)
     receipt_date = db.Column("RECEIPT_DATE", db.DateTime)
     created_date = db.Column("DATE_CREATED", db.DateTime)
+    modified_date = db.Column("DATE_LAST_UPDATED", db.DateTime)
 
     # relationships
     approvers = db.relationship("Approver", backref="location")
@@ -33,6 +34,7 @@ class Receipt(db.Base):
         "desc",
         "agency",
         "created_date",
+        "modified_date",
     )
 
 
@@ -57,10 +59,12 @@ class Approver(db.Base):
     order = db.Column("ORDER_SEQUENCE", db.Integer, primary_key=True)
     proxy_approver = db.Column("PROXY_USER_ID", db.String)
     requested_date = db.Column("RECEIT_REQ_APP_DATE", db.DateTime)
+    approval_date = db.Column("APPROVAL_DATE", db.DateTime)
 
     # column list for querying
     columns = (
         "approver",
         "proxy_approver",
         "requested_date",
+        "approval_date",
     )

--- a/app/tests/integration_tests/aging_report/test_main.py
+++ b/app/tests/integration_tests/aging_report/test_main.py
@@ -90,7 +90,7 @@ class TestGetReceiptQueue:
         # setup
         cols = list(constants.CITIBUY["receipt_cols"].values())
         # execution
-        output = mock_aging.get_receiptg_queue()
+        output = mock_aging.get_receipt_queue()
         print(output)
         # validation
         assert list(output.columns) == cols

--- a/app/tests/unit_tests/citibuy/data.py
+++ b/app/tests/unit_tests/citibuy/data.py
@@ -125,6 +125,7 @@ RECEIPT_RESULTS = [
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
         "unit": mock_data.LOCATIONS["building"]["desc"],
+        "approval_date": None,
     },
     {
         **mock_data.RECEIPTS["receipt2"],
@@ -133,6 +134,7 @@ RECEIPT_RESULTS = [
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
         "unit": mock_data.LOCATIONS["fleet"]["desc"],
+        "approval_date": None,
     },
     {
         **mock_data.RECEIPTS["receipt2"],
@@ -141,5 +143,15 @@ RECEIPT_RESULTS = [
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
         "unit": mock_data.LOCATIONS["fleet"]["desc"],
+        "approval_date": None,
+    },
+    {
+        **mock_data.RECEIPTS["receipt3"],
+        "approval_nbr": 1,
+        "approver": "JOHNSMITH",
+        "proxy_approver": "MICKEYMOUSE",
+        "requested_date": datetime(2020, 9, 1),
+        "unit": mock_data.LOCATIONS["building"]["desc"],
+        "approval_date": datetime(2025, 9, 1),
     },
 ]

--- a/app/tests/utils/citibuy_data.py
+++ b/app/tests/utils/citibuy_data.py
@@ -447,6 +447,7 @@ RECEIPTS = {
         "desc": INVOICES["inv3"]["invoice_nbr"],
         "agency": "DGS",
         "created_date": datetime(2020, 9, 1),
+        "modified_date": datetime(2025, 9, 1),
     },
     "receipt2": {
         "receipt_id": "D002",
@@ -458,6 +459,7 @@ RECEIPTS = {
         "desc": INVOICES["inv4"]["invoice_nbr"],
         "agency": "DGS",
         "created_date": datetime(2020, 9, 1),
+        "modified_date": datetime(2025, 9, 1),
     },
     "receipt3": {
         "receipt_id": "D003",
@@ -467,8 +469,33 @@ RECEIPTS = {
         "owner": "JOHNDOE",
         "loc_id": LOCATIONS["building"]["loc_id"],
         "desc": INVOICES["inv5"]["invoice_nbr"],
+        "agency": "DGS",
+        "created_date": datetime(2020, 9, 1),
+        "modified_date": datetime(2025, 9, 1),
+    },
+    "receipt4": {
+        "receipt_id": "D004",
+        "po_nbr": "P333",
+        "release_nbr": 0,
+        "status": "5CA",
+        "owner": "JOHNDOE",
+        "loc_id": LOCATIONS["building"]["loc_id"],
+        "desc": INVOICES["inv7"]["invoice_nbr"],
+        "agency": "DGS",
+        "created_date": datetime(2020, 9, 1),
+        "modified_date": datetime(2020, 9, 1),
+    },
+    "receipt5": {
+        "receipt_id": "D005",
+        "po_nbr": "P333",
+        "release_nbr": 0,
+        "status": "5CA",
+        "owner": "JOHNDOE",
+        "loc_id": LOCATIONS["building"]["loc_id"],
+        "desc": INVOICES["inv7"]["invoice_nbr"],
         "agency": "DPW",
         "created_date": datetime(2020, 9, 1),
+        "modified_date": datetime(2020, 9, 1),
     },
 }
 
@@ -481,6 +508,7 @@ APPROVERS = {
         "order": 1,
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
+        "approval_date": None,
     },
     "approver1.2P": {
         "receipt_id": RECEIPTS["receipt1"]["receipt_id"],
@@ -489,6 +517,7 @@ APPROVERS = {
         "order": 2,
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
+        "approval_date": None,
     },
     "approver2.1P": {
         "receipt_id": RECEIPTS["receipt2"]["receipt_id"],
@@ -497,6 +526,7 @@ APPROVERS = {
         "order": 2,
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
+        "approval_date": None,
     },
     "approver2.1A": {
         "receipt_id": RECEIPTS["receipt2"]["receipt_id"],
@@ -505,6 +535,7 @@ APPROVERS = {
         "order": 2,
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
+        "approval_date": None,
     },
     "approver3.1P": {
         "receipt_id": RECEIPTS["receipt3"]["receipt_id"],
@@ -513,5 +544,15 @@ APPROVERS = {
         "order": 2,
         "proxy_approver": "MICKEYMOUSE",
         "requested_date": datetime(2020, 9, 1),
+        "approval_date": datetime(2025, 9, 1),
+    },
+    "approver4.1P": {
+        "receipt_id": RECEIPTS["receipt4"]["receipt_id"],
+        "approver_type": "P",
+        "approver": "JANEDOE",
+        "order": 1,
+        "proxy_approver": "JOHNSMITH",
+        "requested_date": datetime(2020, 9, 1),
+        "approval_date": datetime(2020, 9, 1),
     },
 }


### PR DESCRIPTION
## Summary

Concise description of changes proposed in this pull request

Fixes #127 

## Changes Proposed

- Adds `modified_date` to the `Receipt` model and `approval_date` to the `Approver` model
- Adds `days_ago` parameter to the `CitiBuy.get_receipts()` method which includes invoices that were approved up to x days ago
- Adds `receipt_window` parameter to the `AgingReport.get_receipt_queue()` method and sets the default value to 365 days

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. Run `pytest` and all tests should pass
1. Run `pytest tests/integration_tests/aging_report` and all tests should pass
