### PR TITLE
feat: Create an `aging_report` entrypoint (#131)

### DIFF
--- a/app/src/dgs_fiscal/runner.py
+++ b/app/src/dgs_fiscal/runner.py
@@ -1,7 +1,5 @@
 import typer
 
-from dgs_fiscal import etl
-
 # instantiate typer app
 app = typer.Typer()
 
@@ -15,6 +13,8 @@ def hello_world(name: str):
 @app.command(name="contract_management")
 def run_contract_management_etl():
     """Run the contract management workflow"""
+
+    from dgs_fiscal import etl  # pylint: disable=import-outside-toplevel
 
     # init the ETL workflow class
     typer.echo("Starting the contract management workflow")
@@ -48,4 +48,27 @@ def run_contract_management_etl():
         vendor_lookup=vendor_output.mapping,
         contract_lookup=contract_output.mapping,
     )
+    typer.echo("Workflow ran successfully")
+
+
+@app.command(name="aging_report")
+def run_aging_report_etl():
+    """Run the contract management workflow"""
+
+    from dgs_fiscal import etl  # pylint: disable=import-outside-toplevel
+
+    # init the ETL workflow class
+    typer.echo("Starting the aging report workflow")
+    aging_etl = etl.AgingReport()
+
+    # get data from CitiBuy and SharePoint
+    typer.echo("Exporting invoice and receipt data from CitiBuy")
+    invoice_data = aging_etl.get_citibuy_data(invoice_window=365)
+    receipt_data = aging_etl.get_receipt_queue(receipt_window=365)
+
+    # get data from CitiBuy and SharePoint
+    typer.echo("Uploading the exported data to SharePoint")
+    aging_etl.update_sharepoint(invoice_data, "InvoiceExport")
+    aging_etl.update_sharepoint(receipt_data, "ReceiptExport")
+
     typer.echo("Workflow ran successfully")

--- a/app/tests/unit_tests/runner/mock_etl.py
+++ b/app/tests/unit_tests/runner/mock_etl.py
@@ -1,4 +1,6 @@
 # pylint: disable=unused-argument
+import pandas as pd
+
 from dgs_fiscal.etl.contract_management import ContractData, UpdateResult
 
 
@@ -24,3 +26,21 @@ class MockContractManagement:
     def update_po_list(self, old, new, vendor_lookup, contract_lookup):
         """Mock version of update_po_list() for CLI tests"""
         return UpdateResult(mapping={}, upserts={}, results={})
+
+
+class MockAgingReport:
+    """Mock version of ContractManagement class for CLI tests"""
+
+    def get_citibuy_data(self, invoice_window: int = 365) -> pd.DataFrame:
+        """Mock version of get_citibuy_data() for CLI tests"""
+        print(invoice_window)
+        return pd.DataFrame({"Col A": [1, 2, 3], "Col B": ["A", "B", "C"]})
+
+    def get_receipt_queue(self, receipt_window: int = 365) -> pd.DataFrame:
+        """Mock version of get_citibuy_data() for CLI tests"""
+        print(receipt_window)
+        return pd.DataFrame({"Col A": [1, 2, 3], "Col B": ["A", "B", "C"]})
+
+    def update_sharepoint(self, df: pd.DataFrame, report_name: str):
+        """Mock version of update_po_list() for CLI tests"""
+        print(report_name)

--- a/app/tests/unit_tests/runner/test_runner.py
+++ b/app/tests/unit_tests/runner/test_runner.py
@@ -26,6 +26,18 @@ def fixture_contract_mgmt_etl(monkeypatch):
     )
 
 
+@pytest.fixture(name="aging_etl")
+def fixture_aging_etl(monkeypatch):
+    """Monkeypatches the ContractManagement ETL class with the test class
+    MockContractManagement to prevent calls to Citibuy or SharePoint
+    """
+    monkeypatch.setattr(
+        etl,
+        "AgingReport",
+        mock_etl.MockAgingReport,
+    )
+
+
 def test_entrypoint():
     """Tests that the entrypoints specified in setup.py work correctly"""
     # execution
@@ -75,6 +87,29 @@ def test_contract_management(
     ]
     # execution
     result = runner.invoke(app, ["contract_management"])
+    print(result.stdout)
+    # validation
+    assert result.exit_code == 0
+    for message in messages:
+        assert message in result.stdout
+
+
+def test_aging_report(runner, aging_etl):  # pylint: disable=unused-argument
+    """Tests that the contract_management command
+
+    Validates the following conditions:
+    - The command executes with exit code 0 (success)
+    - The correct messages are printed to the console
+    """
+    # setup
+    messages = [
+        "Starting the aging report workflow",
+        "Exporting invoice and receipt data from CitiBuy",
+        "Uploading the exported data to SharePoint",
+        "Workflow ran successfully",
+    ]
+    # execution
+    result = runner.invoke(app, ["aging_report"])
     print(result.stdout)
     # validation
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary

This CLI entrypoint triggers the execution of the AgingReport ETL class methods which export invoices and receipts from CitiBuy and upload that data to SharePoint

Fixes #109 
Fixes #94 

## Changes Proposed

- Creates a `run_aging_report()` function that executes the steps of the Aging Report method
- Adds an `aging_report` entry point to the `typer` app which executes the `run_aging_report()` method

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. {Step 2}
1. {Step 3}
