### PR TITLE
bug: Fixes failing tests in test_archive.py

### DIFF
--- a/app/tests/integration_tests/prompt_payment/test_prompt_payment.py
+++ b/app/tests/integration_tests/prompt_payment/test_prompt_payment.py
@@ -25,7 +25,6 @@ def new_report_file():
 class TestPromptPayment:
     """Tests the PromptPayment etl class"""
 
-    @pytest.mark.skip
     def test_init(self, test_prompt, test_archive_dir):
         """Tests that the PromptPayment inits correctly"""
         # validation
@@ -33,7 +32,6 @@ class TestPromptPayment:
         assert isinstance(test_prompt.core_integrator, CoreIntegrator)
         assert isinstance(test_prompt.sharepoint, SharePoint)
 
-    @pytest.mark.skip
     def test_get_old_report(self, test_prompt):
         """Tests that the get_old_report() method executes successfully
 

--- a/app/tests/integration_tests/sharepoint/test_archive.py
+++ b/app/tests/integration_tests/sharepoint/test_archive.py
@@ -93,6 +93,8 @@ class TestArchiveFolder:
         file_name = "test_download.csv"
         tmp_dir = test_archive_dir / "tmp"
         if tmp_dir.exists():
+            for file in tmp_dir.iterdir():
+                file.unlink()
             assert not any(tmp_dir.iterdir())
         file = test_archive.get_last_upload(TEST_FOLDER)
         # execution


### PR DESCRIPTION
## Summary

The lingering files downloaded by `test_driver.py` caused the tests in `test_archive.py` to fail. This commit clears out any remaining files before checking the directory is empty. It also unskips a few tests in `test_prompt_payment.py`

Fixes #132 

## Changes Proposed

- Unskips tests in `test_prompt_payment.py`
- Updates `test_archive.py` to delete any lingering files in the the test archive before running the download test

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. {Step 2}
1. {Step 3}
