### PR TITLE
refactor: Extends receipt window from 365 to 1200 days

### DIFF
--- a/app/src/dgs_fiscal/runner.py
+++ b/app/src/dgs_fiscal/runner.py
@@ -64,7 +64,7 @@ def run_aging_report_etl():
     # get data from CitiBuy and SharePoint
     typer.echo("Exporting invoice and receipt data from CitiBuy")
     invoice_data = aging_etl.get_citibuy_data(invoice_window=365)
-    receipt_data = aging_etl.get_receipt_queue(receipt_window=365)
+    receipt_data = aging_etl.get_receipt_queue(receipt_window=1200)
 
     # get data from CitiBuy and SharePoint
     typer.echo("Uploading the exported data to SharePoint")

--- a/app/tests/unit_tests/runner/test_runner.py
+++ b/app/tests/unit_tests/runner/test_runner.py
@@ -106,6 +106,7 @@ def test_aging_report(runner, aging_etl):  # pylint: disable=unused-argument
         "Starting the aging report workflow",
         "Exporting invoice and receipt data from CitiBuy",
         "Uploading the exported data to SharePoint",
+        "1200",
         "Workflow ran successfully",
     ]
     # execution


### PR DESCRIPTION
## Summary

Changes the number of days passed to the `receipt_window` parameter in `AgingReport.get_receipt_queue()` when it is called in `run_aging_report_workflow()` to include invoices approved up to 3 years ago.

Fixes #134 

## Changes Proposed

- Changes `receipt_window=365` to `receipt_window=1200`
- Checks for invoked receipt window in `test_runner.py`

## Instructions to Review

1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
1. {Step 2}
1. {Step 3}
